### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
-FROM python:3.8-buster
+FROM osgeo/gdal:ubuntu-small-latest
 
-RUN echo deb http://ftp.uk.debian.org/debian unstable main contrib non-free >> /etc/apt/sources.list && \
-    apt-get update && apt-get upgrade -y && \
-    apt-get remove -y binutils && \
-    apt-get -t unstable install -y libgdal-dev g++ && \
-    apt-get install -y gettext && \
-    apt-get clean
+RUN apt-get install python3-pip -y
 
 # Update C env vars so compiler can find gdal
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
@@ -17,12 +12,10 @@ RUN mkdir -p /code/app_data && \
 
 VOLUME /code/app_data
 VOLUME /code/tempfiles
-VOLUME /postgresdata
 
 WORKDIR /code
-ADD requirements.txt /code/
-RUN pip install -r requirements.txt
+
+COPY . /code/
+RUN pip3 install -r requirements.txt
 
 
-
-ADD . /code/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM osgeo/gdal:ubuntu-small-latest
+FROM osgeo/gdal:ubuntu-small-3.1.0
 
-RUN apt-get install python3-pip -y
+RUN apt-get update
+RUN apt-get install python3-pip -y && \
+    apt-get install libcairo2-dev -y && \
+    apt-get install build-essential python3-dev python3-setuptools python3-wheel python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info -y
 
 # Update C env vars so compiler can find gdal
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
@@ -8,21 +11,23 @@ ENV C_INCLUDE_PATH=/usr/include/gdal
 
 ENV PYTHONUNBUFFERED 1
 RUN mkdir -p /code/app_data && \
-    mkdir -p /code/tempfiles
+    mkdir -p /code/tempfiles && \
+    mkdir -p /build-files
 
 VOLUME /code/app_data
 VOLUME /code/tempfiles
 
+#For production
 COPY . /code/
 
-WORKDIR /code
+# Copy files in another location to solved windows rights issues
+# These files are only used during build process and by entrypoint.sh for dev
+COPY . /build-files/
+WORKDIR /build-files/
 
-
-RUN chmod 777 /code/entrypoint.sh \
-    && ln -s /code/entrypoint.sh /
-
+# Required to fix rights when used on windows
+RUN chmod 777 /build-files/entrypoint.sh \
+    && ln -s /build-files/entrypoint.sh /
 
 RUN pip3 install -r requirements.txt
-RUN pip3 install tablib
-
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,16 @@ RUN mkdir -p /code/app_data && \
 VOLUME /code/app_data
 VOLUME /code/tempfiles
 
+COPY . /code/
+
 WORKDIR /code
 
-COPY . /code/
+
+RUN chmod 777 /code/entrypoint.sh \
+    && ln -s /code/entrypoint.sh /
+
+
 RUN pip3 install -r requirements.txt
+RUN pip3 install tablib
 
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - "postgres"
     build: ./
-    entrypoint: entrypoint.sh
+    entrypoint: /build-files/entrypoint.sh
     command: python3 manage.py runserver 0.0.0.0:9000
     volumes:
       - .:/code #DEV ONLY!!!

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - "postgres"
     build: ./
-    entrypoint: /code/entrypoint.sh
+    entrypoint: entrypoint.sh
     command: python3 manage.py runserver 0.0.0.0:9000
     volumes:
       - .:/code #DEV ONLY!!!

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,13 +12,12 @@ do
     sleep 1
 done
 
-cd /code
+cd /build-files
 # rename demo env file
 cp -n env.yaml_demo env.yaml
 # setup app using the django tools
 python3 manage.py migrate
 echo yes | python3 manage.py compilemessages -l fr
-echo yes | python3 manage.py collectstatic
 
 python3 manage.py loaddata db.json
 

--- a/geomapshark/settings.py
+++ b/geomapshark/settings.py
@@ -34,7 +34,9 @@ ALLOWED_HOSTS = ['gmf23-mapnv.preprod.sig.cloud.camptocamp.com',
                 'pro.mapnv.ch',
                 'mapnv.ch',
                  'localhost',
-                 '127.0.0.1']
+                 '127.0.0.1',
+                 'geocity-dev.mapnv.ch',
+                 'construire.mapnv.ch',]
 
 DATE_INPUT_FORMAT = [
     '%Y-%m-%d', '%m/%d/%Y', '%m/%d/%y', # '2006-10-25', '10/25/2006', '10/25/06'

--- a/requirements.in
+++ b/requirements.in
@@ -17,3 +17,5 @@ PyYAML
 requests
 WeasyPrint
 whitenoise
+tablib
+pycairo

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ jdcal==1.4.1              # via -r requirements.in
 pillow==6.2.1             # via -r requirements.in, cairosvg
 pip-tools==5.1.1          # via -r requirements.in
 psycopg2-binary==2.8.5    # via -r requirements.in
+pycairo==1.19.1           # via -r requirements.in
 pycparser==2.19           # via cffi
 pyphen==0.9.5             # via weasyprint
 pytz==2019.3              # via -r requirements.in, django
@@ -35,6 +36,7 @@ requests==2.22.0          # via -r requirements.in
 six==1.12.0               # via html5lib, pip-tools
 soupsieve==1.9.4          # via beautifulsoup4
 sqlparse==0.3.0           # via django
+tablib==1.1.0             # via -r requirements.in
 tinycss2==1.0.2           # via cairosvg, cssselect2, weasyprint
 urllib3==1.25.6           # via requests
 weasyprint==50            # via -r requirements.in


### PR DESCRIPTION
@sephii , @nicolas-sitylb 
- Change base docker image to official osge/gdal/ubuntu image (gdal 3.1.0, ubuntu 20). Using small image
- Add missing lib to image: gettext, cairo, pango, ...
- Add missing dependencies to python: tablib + pycairo

@sephii please merge. Tested on both windows & ubuntu