### PR TITLE
whitelist ip for endpoints

### DIFF
--- a/geomapshark/settings.py
+++ b/geomapshark/settings.py
@@ -122,6 +122,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         "MAX_FILE_UPLOAD_SIZE",
         "GEOCALENDAR_URL",
         "ENABLE_GEOCALENDAR",
+        "ENDPOINT_WHITELIST",
     ),
     "Theme Options": (
         "BACKGROUND_COLOR",
@@ -213,6 +214,11 @@ CONSTANCE_CONFIG = {
     "TEXT_COLOR": ("#000000", "Couleur du texte", str,),
     "TITLE_COLOR": ("#000000", "Couleur du titre", str,),
     "TABLE_COLOR": ("#212529", "Couleur du texte dans les tableaux", str,),
+    "ENDPOINT_WHITELIST": (
+        "127.0.0.1,192.168.,172.",
+        "Liste d'adresses ip autorisées à requêter les endpoints DRF non publics, séparées par des virgules sans espace",
+        str,
+    ),
 }
 
 TEMPLATES = [

--- a/permits/api.py
+++ b/permits/api.py
@@ -8,6 +8,8 @@ from rest_framework import viewsets
 from rest_framework.permissions import BasePermission, IsAuthenticated
 
 from . import geoservices, models, serializers, services
+from constance import config
+
 
 # ///////////////////////////////////
 # DJANGO REST API
@@ -108,7 +110,13 @@ class BlockRequesterUserPermission(BasePermission):
     """
 
     def has_permission(self, request, view):
-        return request.user.get_all_permissions()
+        remote_addr = request.META["REMOTE_ADDR"]
+
+        for whitelisted in config.ENDPOINT_WHITELIST.split(","):
+            if remote_addr == whitelisted or remote_addr.startswith(valid_ip):
+                return request.user.get_all_permissions()
+        else:
+            return []
 
 
 class PermitRequestViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
This PR add check for remote host ip for accessing permits endpoints. White list is defined in constance variable

In order not to block docker private ip in dev mode, private ip are whitelisted by default. But this can change in production through constance variable ENDPOINT_WHITELIST

@AlexandreJunod please review & merge