### PR TITLE
Allow to access external WMS layers with referrer check

### DIFF
--- a/templates/base_generic.html
+++ b/templates/base_generic.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
     <title>{% block title %}{% endblock %}Geocity</title>
     {% load static %}
     {% load i18n %}


### PR DESCRIPTION
Using the default value `strict-origin-when-cross-origin` allows to access external WMS layers with referrer check.

Doc: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

Please review.