### PR TITLE
Hotfix/docker

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,20 +1,20 @@
 version: "3"
 
 volumes:
-    gmsdata:
-    pgdata:
+    gmsdata: {}
+    pgdata: {}
 
 services:
     web:
         image: gms_web
         restart: unless-stopped
         depends_on:
-            - "qgisserver"
-            - "postgres"
+            - qgisserver
+            - postgres
         build:
             context: ./
             args:
-                dev_dependencies: ${DEV_DEPENDENCIES}
+                dev_dependencies: "${DEV_DEPENDENCIES}"
         entrypoint: /code/entrypoint_dev.sh
         command: "python3 manage.py runserver 0.0.0.0:9000"
         volumes:
@@ -29,7 +29,7 @@ services:
         image: openquake/qgis-server:3.16
         restart: unless-stopped
         depends_on:
-            - "postgres"
+            - postgres
         volumes:
             - ./qgisserver/geocity.qgs:/io/data/geocity.qgs:ro #default qgis project for mask layer
             - ./qgisserver/pg_service.conf:/etc/postgresql-common/pg_service.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,11 @@ services:
         build:
             context: ./
             args:
-                dev_dependencies: ${DEV_DEPENDENCIES}
+                dev_dependencies: "${DEV_DEPENDENCIES}"
         entrypoint: /code/entrypoint.sh
         command: "gunicorn geomapshark.wsgi -b :9000 --error-logfile gunicorn_log.log --workers=2 --threads=4 --worker-class=gthread"
         volumes:
-            - ${PRIVATE_DOCUMENTS_DIR}:/private_documents
+            - "${PRIVATE_DOCUMENTS_DIR}:/private_documents"
             - qgis_projects:/qgis_projects
         ports:
             - "${DJANGO_DOCKER_PORT}:9000"
@@ -27,7 +27,7 @@ services:
         volumes:
             - ./qgisserver/geocity.qgs:/io/data/geocity.qgs:ro
             - ./qgisserver/pg_service.conf:/etc/postgresql-common/pg_service.conf:ro
-            - ${PRIVATE_DOCUMENTS_DIR}:/private_documents
+            - "${PRIVATE_DOCUMENTS_DIR}:/private_documents"
         ports:
             - "${QGISSERVER_DOCKER_PORT}:80"
         environment:


### PR DESCRIPTION
To fix the following error message on Windows:    
`services.web.build.args.dev_dependencies must be a string, number or null`
the variable `${DEV_DEPENDENCIES}` **must** apparently be quoted.