### PR TITLE
[DRAFT] OGC Features API (wfs3) endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ ARG dev_dependencies
 # Copy files in another location to solved windows rights issues
 # These files are only used during build process and by entrypoint.sh for dev
 
-COPY . /code/
 WORKDIR /code
+COPY requirements_dev.txt requirements_dev.txt
+COPY requirements.txt requirements.txt
 
 RUN if [ "$dev_dependencies" = "true" ] ; \
     then \
@@ -23,3 +24,5 @@ RUN if [ "$dev_dependencies" = "true" ] ; \
     && echo "# Installed production dependencies    #" \
     && echo "########################################"; \
     fi
+
+COPY . /code/

--- a/django_wfs3/README.md
+++ b/django_wfs3/README.md
@@ -54,5 +54,4 @@ WFS3_DESCRIPTION = "Description"
 
 This is probably still relatively far from a full OGC Services API implementation and currently only aims to support read-only view from QGIS.
 
-This app will as some point be factored out
-into a reusable Django library.
+This app will at some point be factored out into a reusable Django library.

--- a/django_wfs3/README.md
+++ b/django_wfs3/README.md
@@ -8,22 +8,46 @@ serialization, authentication, etc.).
 
 ## Usage
 
+> NOTE : these snippets are not tested and may require fixing/adaptations.
+
 Add this to your `urls.py` :
 
 Register your viewset in the wfs3 router
 ```python
-
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from django_wfs3.urls import wfs3_router
-from .viewsets import MyModelViewSet
+
+class MyModelSerializer(gis_serializers.GeoFeatureModelSerializer):
+    class Meta:
+        model = MyModel
+        fields = "__all__"
+        geo_field = "geom"
+
+class MyModelViewset(WFS3DescribeModelViewSetMixin, viewsets.ModelViewSet):
+    queryset = MyModel.objects.all()
+    serializer_class = MyModelSerializer
+
+    wfs3_title = "layer title"
+    wfs3_description = "layer_description"
+    wfs3_geom_lookup = 'geom'  # (one day this will be retrieved automatically from the serializer)
+    wfs3_srid = 2056  # (one day this will be retrieved automatically from the DB field)
 
 wfs3_router.register(r"permits", MyModelViewSet, "permits")
 ```
 
-Add the router to your `urls.py`
+Add the router to your `urls.py`:
+
 ```python
 urlpatterns += [
     path("wfs3/", include(django_wfs3.urls))
 ]
+```
+
+Optionally specify your endpoint's metadata in `settings.py`:
+
+```python
+WFS3_TITLE = "My Endpoint"
+WFS3_DESCRIPTION = "Description"
 ```
 
 ## Roadmap / status

--- a/django_wfs3/README.md
+++ b/django_wfs3/README.md
@@ -1,0 +1,34 @@
+# Django WFS3
+
+This Django app implements an OGC Services API (a.k.a. WFS3) for Django.
+
+It provides a Django Rest Framework (DRF) specific router to which you can
+regsiter your Viewsets, and thus benefit from all DRF's features (permissions,
+serialization, authentication, etc.).
+
+## Usage
+
+Add this to your `urls.py` :
+
+Register your viewset in the wfs3 router
+```python
+
+from django_wfs3.urls import wfs3_router
+from .viewsets import MyModelViewSet
+
+wfs3_router.register(r"permits", MyModelViewSet, "permits")
+```
+
+Add the router to your `urls.py`
+```python
+urlpatterns += [
+    path("wfs3/", include(django_wfs3.urls))
+]
+```
+
+## Roadmap / status
+
+This is probably still relatively far from a full OGC Services API implementation and currently only aims to support read-only view from QGIS.
+
+This app will as some point be factored out
+into a reusable Django library.

--- a/django_wfs3/mixins.py
+++ b/django_wfs3/mixins.py
@@ -1,29 +1,61 @@
 from rest_framework.response import Response
 from rest_framework.decorators import action
 
+from django.contrib.gis.db.models import Extent
 
-class WFS3DescribeModelMixin:
+from django_wfs3.urls import wfs3_router
+
+class WFS3DescribeModelViewSetMixin:
     """
-    Describe endpoint for WFS3
+    Adds describe endpoint used by WFS3 routers
     """
 
-    # TODO : see if we need this anyway, as all info is already in wfs3/collections
-    def describe(self, request, *args, **kwargs):
-        return Response(
-            {
-                "id": "permit",  # TODO - how can we retrieve prefix from here ?
-                "title": "permit",  # TODO - how can we retrieve prefix from here ?
-                "description": "?",
-                "extent": {
-                    "spatial": {"bbox": [[7.01, 50.63, 7.22, 50.78]]},  # TODO - retrieve from the viewset
+    def _describe(self, request, base_url):
+        # retrieve the key under which this viewset was registered in the wfs3 router
+        key = None
+        for prefix, viewset, basename in wfs3_router.registry:
+            if viewset is self.__class__:
+                key = prefix
+                break
+        else:
+            raise Exception(f"Did not find {self} in {wfs3_router.registry}")
+
+        # retrieve wfs3 config defined on the viewset
+        title = getattr(self, "wfs3_title", f"Layer {key}")
+        description = getattr(self, "wfs3_description", "No description")
+        srid = getattr(self, "wfs3_srid", 4326)
+        extents = self.get_queryset().aggregate(e=Extent(self.wfs3_geom_lookup))["e"]
+
+        # return the wfs3 layer description as an object
+        return {
+            "id": key,
+            "title": title,
+            "description": description,
+            "extent": {
+                "spatial": {
+                    "bbox": [extents],
+                    "crs": f"http://www.opengis.net/def/crs/EPSG/0/{srid}",  # seems this isn't recognized by QGIS ?
                 },
-                "links": [
-                    {
-                        "href": request.build_absolute_uri("items/"),
-                        "rel": "items",
-                        "type": "application/geo+json",
-                        "title": "permit",  # TODO - how can we retrieve prefix from here ?
-                    },
-                ],
-            }
-        )
+            },
+            "crs": [
+                f"http://www.opengis.net/def/crs/EPSG/0/{srid}",  # seems this isn't recognized by QGIS ?
+            ],
+            "links": [
+                {
+                    "href": request.build_absolute_uri(f"{base_url}{key}"),
+                    "rel": "self",
+                    "type": "application/geo+json",
+                    "title": "This document as JSON",
+                },
+                {
+                    "href": request.build_absolute_uri(f"{base_url}{key}/items"),
+                    "rel": "items",
+                    "type": "application/geo+json",
+                    "title": key,  # TODO - how can we retrieve prefix from here ?
+                },
+            ],
+        }
+
+    def describe(self, request, *args, **kwargs):
+        """Implementation of the `describe` endpoint"""
+        return Response(self._describe(request, base_url=""))

--- a/django_wfs3/mixins.py
+++ b/django_wfs3/mixins.py
@@ -19,7 +19,7 @@ class WFS3DescribeModelMixin:
                 },
                 "links": [
                     {
-                        "href": request.build_absolute_uri("items"),
+                        "href": request.build_absolute_uri("items/"),
                         "rel": "items",
                         "type": "application/geo+json",
                         "title": "permit",  # TODO - how can we retrieve prefix from here ?

--- a/django_wfs3/mixins.py
+++ b/django_wfs3/mixins.py
@@ -52,7 +52,7 @@ class WFS3DescribeModelViewSetMixin:
                     "href": request.build_absolute_uri(f"{base_url}{key}/items"),
                     "rel": "items",
                     "type": "application/geo+json",
-                    "title": key,  # TODO - how can we retrieve prefix from here ?
+                    "title": key,
                 },
             ],
         }

--- a/django_wfs3/mixins.py
+++ b/django_wfs3/mixins.py
@@ -7,6 +7,7 @@ class WFS3DescribeModelMixin:
     Describe endpoint for WFS3
     """
 
+    # TODO : see if we need this anyway, as all info is already in wfs3/collections
     def describe(self, request, *args, **kwargs):
         return Response(
             {
@@ -14,8 +15,7 @@ class WFS3DescribeModelMixin:
                 "title": "permit",  # TODO - how can we retrieve prefix from here ?
                 "description": "?",
                 "extent": {
-                    "spatial": {"bbox": [[7.01, 50.63, 7.22, 50.78]]},
-                    "temporal": {"interval": [["2010-02-15T12:34:56Z", None]]},
+                    "spatial": {"bbox": [[7.01, 50.63, 7.22, 50.78]]},  # TODO - retrieve from the viewset
                 },
                 "links": [
                     {

--- a/django_wfs3/mixins.py
+++ b/django_wfs3/mixins.py
@@ -24,24 +24,6 @@ class WFS3DescribeModelMixin:
                         "type": "application/geo+json",
                         "title": "permit",  # TODO - how can we retrieve prefix from here ?
                     },
-                    # {
-                    #     "href": "http://data.example.org/collections/buildings/items.html",
-                    #     "rel": "items",
-                    #     "type": "text/html",
-                    #     "title": "Buildings",
-                    # },
-                    # {
-                    #     "href": "https://creativecommons.org/publicdomain/zero/1.0/",
-                    #     "rel": "license",
-                    #     "type": "text/html",
-                    #     "title": "CC0-1.0",
-                    # },
-                    # {
-                    #     "href": "https://creativecommons.org/publicdomain/zero/1.0/rdf",
-                    #     "rel": "license",
-                    #     "type": "application/rdf+xml",
-                    #     "title": "CC0-1.0",
-                    # },
                 ],
             }
         )

--- a/django_wfs3/mixins.py
+++ b/django_wfs3/mixins.py
@@ -1,0 +1,47 @@
+from rest_framework.response import Response
+from rest_framework.decorators import action
+
+
+class WFS3DescribeModelMixin:
+    """
+    Describe endpoint for WFS3
+    """
+
+    def describe(self, request, *args, **kwargs):
+        return Response(
+            {
+                "id": "permit",  # TODO - how can we retrieve prefix from here ?
+                "title": "permit",  # TODO - how can we retrieve prefix from here ?
+                "description": "?",
+                "extent": {
+                    "spatial": {"bbox": [[7.01, 50.63, 7.22, 50.78]]},
+                    "temporal": {"interval": [["2010-02-15T12:34:56Z", None]]},
+                },
+                "links": [
+                    {
+                        "href": request.build_absolute_uri("items"),
+                        "rel": "items",
+                        "type": "application/geo+json",
+                        "title": "permit",  # TODO - how can we retrieve prefix from here ?
+                    },
+                    # {
+                    #     "href": "http://data.example.org/collections/buildings/items.html",
+                    #     "rel": "items",
+                    #     "type": "text/html",
+                    #     "title": "Buildings",
+                    # },
+                    # {
+                    #     "href": "https://creativecommons.org/publicdomain/zero/1.0/",
+                    #     "rel": "license",
+                    #     "type": "text/html",
+                    #     "title": "CC0-1.0",
+                    # },
+                    # {
+                    #     "href": "https://creativecommons.org/publicdomain/zero/1.0/rdf",
+                    #     "rel": "license",
+                    #     "type": "application/rdf+xml",
+                    #     "title": "CC0-1.0",
+                    # },
+                ],
+            }
+        )

--- a/django_wfs3/mixins.py
+++ b/django_wfs3/mixins.py
@@ -5,6 +5,7 @@ from django.contrib.gis.db.models import Extent
 
 from django_wfs3.urls import wfs3_router
 
+
 class WFS3DescribeModelViewSetMixin:
     """
     Adds describe endpoint used by WFS3 routers

--- a/django_wfs3/pagination.py
+++ b/django_wfs3/pagination.py
@@ -1,14 +1,17 @@
 from rest_framework import pagination
 from rest_framework.response import Response
 
+
 class CustomPagination(pagination.PageNumberPagination):
     def get_paginated_response(self, data):
-        return Response({
-            'links': {
-                'next': self.get_next_link(),
-                'previous': self.get_previous_link()
-            },
-            'numberReturned': self.page.paginator.count,
-            'numberMatched': len(data),
-            **data
-        })
+        return Response(
+            {
+                "links": {
+                    "next": self.get_next_link(),
+                    "previous": self.get_previous_link(),
+                },
+                "numberReturned": self.page.paginator.count,
+                "numberMatched": len(data),
+                **data,
+            }
+        )

--- a/django_wfs3/pagination.py
+++ b/django_wfs3/pagination.py
@@ -1,0 +1,14 @@
+from rest_framework import pagination
+from rest_framework.response import Response
+
+class CustomPagination(pagination.PageNumberPagination):
+    def get_paginated_response(self, data):
+        return Response({
+            'links': {
+                'next': self.get_next_link(),
+                'previous': self.get_previous_link()
+            },
+            'numberReturned': self.page.paginator.count,
+            'numberMatched': len(data),
+            **data
+        })

--- a/django_wfs3/routers.py
+++ b/django_wfs3/routers.py
@@ -1,6 +1,7 @@
 from rest_framework import routers
 
 from django.urls import path
+from django.conf import settings
 
 from rest_framework.schemas import SchemaGenerator
 from rest_framework.schemas.views import SchemaView
@@ -31,7 +32,10 @@ class WFS3Router(routers.SimpleRouter):
         # List route.
         routers.Route(
             url=r"^collections/{prefix}/items{trailing_slash}$",
-            mapping={"get": "list", "post": "create"},
+            mapping={
+                "get": "list",
+                # "post": "create",
+            },
             name="{basename}-list",
             detail=False,
             initkwargs={"suffix": "List"},
@@ -41,9 +45,9 @@ class WFS3Router(routers.SimpleRouter):
             url=r"^collections/{prefix}/items/{lookup}{trailing_slash}$",
             mapping={
                 "get": "retrieve",
-                "put": "update",
-                "patch": "partial_update",
-                "delete": "destroy",
+                # "put": "update",
+                # "patch": "partial_update",
+                # "delete": "destroy",
             },
             name="{basename}-detail",
             detail=True,
@@ -73,16 +77,22 @@ class WFS3Router(routers.SimpleRouter):
         """Return all WFS3 routes"""
         urls = super().get_urls()
 
+        title = getattr(settings, "WFS3_TITLE", "Django OGC Api Services Endpoint")
+        description = getattr(settings, "WFS3_DESCRIPTION", "No description")
+
         # Root URL
-        root_view = RootView.as_view()
+        root_view = RootView.as_view(
+            title=title,
+            description=description,
+        )
         root_url = path("", root_view, name="capabilities")
         urls.append(root_url)
 
         # Schema
         schema_view = get_schema_view(
-            title="Geocity OGC Features API Endpoint",  # TODO : make customizable
-            description="Access to data from Geocity.",  # TODO : make customizable
-            version="1.0.0",  # TODO : make customizable
+            title=title,
+            description=description,
+            version="1.0.0",
             urlconf=self,
         )
         schema_url = path("api", schema_view, name="service-desc")

--- a/django_wfs3/routers.py
+++ b/django_wfs3/routers.py
@@ -68,6 +68,9 @@ class WFS3Router(routers.SimpleRouter):
         ),
     ]
 
+    def __init__(self):
+        super().__init__(trailing_slash=False)
+
     def get_urls(self):
         """Return all WFS3 routes"""
         urls = super().get_urls()
@@ -79,7 +82,10 @@ class WFS3Router(routers.SimpleRouter):
 
         # Schema
         schema_view = get_schema_view(
-            title="Your Project", description="API for all things …", version="1.0.0", url='http://127.0.0.1:9095'
+            title="Your Project",
+            description="API for all things …",
+            version="1.0.0",
+            urlconf='django_wfs3.urls',
         )
         schema_url = path("api", schema_view, name="service-desc")
         urls.append(schema_url)

--- a/django_wfs3/routers.py
+++ b/django_wfs3/routers.py
@@ -1,19 +1,12 @@
 from rest_framework import routers
-import itertools
-from collections import OrderedDict, namedtuple
 
-from django.core.exceptions import ImproperlyConfigured
-from django.urls import NoReverseMatch, re_path, path
+from django.urls import path
 
-from rest_framework import views
-from rest_framework.response import Response
-from rest_framework.reverse import reverse
 from rest_framework.schemas import SchemaGenerator
 from rest_framework.schemas.views import SchemaView
-from rest_framework.settings import api_settings
 from rest_framework.urlpatterns import format_suffix_patterns
 from rest_framework.schemas import get_schema_view
-from .views import WFS3RootView, CollectionsView
+from .views import RootView, CollectionsView
 
 
 class WFS3Router(routers.SimpleRouter):
@@ -76,7 +69,7 @@ class WFS3Router(routers.SimpleRouter):
         urls = super().get_urls()
 
         # Root URL
-        root_view = WFS3RootView.as_view()
+        root_view = RootView.as_view()
         root_url = path("", root_view, name="capabilities")
         urls.append(root_url)
 

--- a/django_wfs3/routers.py
+++ b/django_wfs3/routers.py
@@ -85,7 +85,6 @@ class WFS3Router(routers.SimpleRouter):
             title="Your Project",
             description="API for all things …",
             version="1.0.0",
-            urlconf='django_wfs3.urls',
         )
         schema_url = path("api", schema_view, name="service-desc")
         urls.append(schema_url)

--- a/django_wfs3/routers.py
+++ b/django_wfs3/routers.py
@@ -56,9 +56,7 @@ class WFS3Router(routers.SimpleRouter):
         # Describe route.
         routers.Route(
             url=r"^collections/{prefix}{trailing_slash}$",
-            mapping={
-                "get": "describe",
-            },
+            mapping={"get": "describe",},
             name="{basename}-describe",
             detail=False,
             initkwargs={"suffix": "List"},
@@ -81,19 +79,13 @@ class WFS3Router(routers.SimpleRouter):
         description = getattr(settings, "WFS3_DESCRIPTION", "No description")
 
         # Root URL
-        root_view = RootView.as_view(
-            title=title,
-            description=description,
-        )
+        root_view = RootView.as_view(title=title, description=description,)
         root_url = path("", root_view, name="capabilities")
         urls.append(root_url)
 
         # Schema
         schema_view = get_schema_view(
-            title=title,
-            description=description,
-            version="1.0.0",
-            urlconf=self,
+            title=title, description=description, version="1.0.0", urlconf=self,
         )
         schema_url = path("api", schema_view, name="service-desc")
         urls.append(schema_url)

--- a/django_wfs3/routers.py
+++ b/django_wfs3/routers.py
@@ -64,6 +64,11 @@ class WFS3Router(routers.SimpleRouter):
     def __init__(self):
         super().__init__(trailing_slash=False)
 
+    @property
+    def urlpatterns(self):
+        """Alias for self.urls, so that we can provide this instance directly to get_schema_view()"""
+        return self.urls
+
     def get_urls(self):
         """Return all WFS3 routes"""
         urls = super().get_urls()
@@ -78,6 +83,7 @@ class WFS3Router(routers.SimpleRouter):
             title="Geocity OGC Features API Endpoint",  # TODO : make customizable
             description="Access to data from Geocity.",  # TODO : make customizable
             version="1.0.0",  # TODO : make customizable
+            urlconf=self,
         )
         schema_url = path("api", schema_view, name="service-desc")
         urls.append(schema_url)

--- a/django_wfs3/routers.py
+++ b/django_wfs3/routers.py
@@ -75,9 +75,9 @@ class WFS3Router(routers.SimpleRouter):
 
         # Schema
         schema_view = get_schema_view(
-            title="Your Project",
-            description="API for all things …",
-            version="1.0.0",
+            title="Geocity OGC Features API Endpoint",  # TODO : make customizable
+            description="Access to data from Geocity.",  # TODO : make customizable
+            version="1.0.0",  # TODO : make customizable
         )
         schema_url = path("api", schema_view, name="service-desc")
         urls.append(schema_url)

--- a/django_wfs3/routers.py
+++ b/django_wfs3/routers.py
@@ -1,0 +1,95 @@
+from rest_framework import routers
+import itertools
+from collections import OrderedDict, namedtuple
+
+from django.core.exceptions import ImproperlyConfigured
+from django.urls import NoReverseMatch, re_path, path
+
+from rest_framework import views
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+from rest_framework.schemas import SchemaGenerator
+from rest_framework.schemas.views import SchemaView
+from rest_framework.settings import api_settings
+from rest_framework.urlpatterns import format_suffix_patterns
+from rest_framework.schemas import get_schema_view
+from .views import WFS3RootView, CollectionsView
+
+
+class WFS3Router(routers.SimpleRouter):
+    """Router to explose a WFS3 Endpoint.
+
+    This works just like a regular DRF router, where you need
+    to register your viewsets using `router.register(...)`.
+
+    It will take care of creating the standard WFS3 routes according
+    to https://app.swaggerhub.com/apis/cportele/ogcapi-features-1-example2/1.0.0#/Capabilities/getCollections
+    """
+
+    include_format_suffixes = True
+    # default_schema_renderers = None
+    APISchemaView = SchemaView
+    SchemaGenerator = SchemaGenerator
+
+    # This is the list of routes that get generated for viewsets.
+    # It is adapted from routers.SimpleRouter but adapts URLs to the specs, and adds the describe URL
+    # NOTE : we don't support routes created with @action(...), if needed copy implementation from SimpleRouter.routes here
+    routes = [
+        # List route.
+        routers.Route(
+            url=r"^collections/{prefix}/items{trailing_slash}$",
+            mapping={"get": "list", "post": "create"},
+            name="{basename}-list",
+            detail=False,
+            initkwargs={"suffix": "List"},
+        ),
+        # Detail route.
+        routers.Route(
+            url=r"^collections/{prefix}/items/{lookup}{trailing_slash}$",
+            mapping={
+                "get": "retrieve",
+                "put": "update",
+                "patch": "partial_update",
+                "delete": "destroy",
+            },
+            name="{basename}-detail",
+            detail=True,
+            initkwargs={"suffix": "Instance"},
+        ),
+        # Describe route.
+        routers.Route(
+            url=r"^collections/{prefix}{trailing_slash}$",
+            mapping={
+                "get": "describe",
+            },
+            name="{basename}-describe",
+            detail=False,
+            initkwargs={"suffix": "List"},
+        ),
+    ]
+
+    def get_urls(self):
+        """Return all WFS3 routes"""
+        urls = super().get_urls()
+
+        # Root URL
+        root_view = WFS3RootView.as_view()
+        root_url = path("", root_view, name="capabilities")
+        urls.append(root_url)
+
+        # Schema
+        schema_view = get_schema_view(
+            title="Your Project", description="API for all things …", version="1.0.0", url='http://127.0.0.1:9095'
+        )
+        schema_url = path("api", schema_view, name="service-desc")
+        urls.append(schema_url)
+
+        # Collections (implementation adapted from DRF's DefaultRouter.get_api_root_view)
+        collections_view = CollectionsView.as_view(registry=self.registry)
+        collections_url = path("collections", collections_view, name="collections")
+        urls.append(collections_url)
+
+        if self.include_format_suffixes:
+            urls = format_suffix_patterns(urls)
+
+        return urls

--- a/django_wfs3/urls.py
+++ b/django_wfs3/urls.py
@@ -1,0 +1,11 @@
+from django.urls import include, path
+
+from permits import api
+from django_wfs3.routers import WFS3Router
+
+
+wfs3_router = WFS3Router()
+
+urlpatterns = [
+    path("", include(wfs3_router.urls)),
+]

--- a/django_wfs3/urls.py
+++ b/django_wfs3/urls.py
@@ -1,11 +1,3 @@
-from django.urls import include, path
-
-from permits import api
-from django_wfs3.routers import WFS3Router
-
+from .routers import WFS3Router
 
 wfs3_router = WFS3Router()
-
-urlpatterns = [
-    path("", include(wfs3_router.urls)),
-]

--- a/django_wfs3/views.py
+++ b/django_wfs3/views.py
@@ -31,7 +31,7 @@ class RootView(views.APIView):
                 "description": self.description,
                 "links": [
                     {
-                        "href": request.build_absolute_uri("/"),
+                        "href": request.build_absolute_uri(""),
                         "rel": "self",
                         "type": "application/json",
                         "title": "this document",

--- a/django_wfs3/views.py
+++ b/django_wfs3/views.py
@@ -27,7 +27,7 @@ class WFS3RootView(views.APIView):
                 "description": "Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Features specification.",
                 "links": [
                     {
-                        "href": request.build_absolute_uri(""),
+                        "href": request.build_absolute_uri("/"),
                         "rel": "self",
                         "type": "application/json",
                         "title": "this document",

--- a/django_wfs3/views.py
+++ b/django_wfs3/views.py
@@ -1,0 +1,165 @@
+from rest_framework import routers
+import itertools
+from collections import OrderedDict, namedtuple
+
+from django.core.exceptions import ImproperlyConfigured
+from django.urls import NoReverseMatch, re_path
+
+from rest_framework import views
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+from rest_framework.schemas import SchemaGenerator
+from rest_framework.schemas.views import SchemaView
+from rest_framework.settings import api_settings
+from rest_framework.urlpatterns import format_suffix_patterns
+
+
+class WFS3RootView(views.APIView):
+    """WFS3 index view.
+
+    This is currently more or less static
+    """
+
+    def get(self, request, *args, **kwargs):
+        return Response(
+            {
+                "title": "Buildings in Bonn",
+                "description": "Access to data about buildings in the city of Bonn via a Web API that conforms to the OGC API Features specification.",
+                "links": [
+                    {
+                        "href": request.build_absolute_uri(""),
+                        "rel": "self",
+                        "type": "application/json",
+                        "title": "this document",
+                    },
+                    {
+                        "href": request.build_absolute_uri("api"),
+                        "rel": "service-desc",
+                        "type": "application/vnd.oai.openapi+json;version=3.0",
+                        "title": "the API definition",
+                    },
+                    # {
+                    #     "href": request.build_absolute_uri("api.html"),
+                    #     "rel": "service-doc",
+                    #     "type": "text/html",
+                    #     "title": "the API documentation",
+                    # },
+                    {
+                        "href": request.build_absolute_uri("conformance"),
+                        "rel": "conformance",
+                        "type": "application/json",
+                        "title": "OGC API conformance classes implemented by this server",
+                    },
+                    {
+                        "href": request.build_absolute_uri("collections"),
+                        "rel": "data",
+                        "type": "application/json",
+                        "title": "Information about the feature collections",
+                    },
+                ],
+            }
+        )
+
+
+class CollectionsView(routers.APIRootView):
+    """Collections index view.
+
+    This is extends DRF's APIRootView as it works in the same way, but just
+    adds some more elements.
+    """
+
+    schema = None  # exclude from schema
+    registry = None
+
+    def get(self, request, *args, **kwargs):
+
+        collections_dict = {}
+        for prefix, viewset, basename in self.registry:
+            collections_dict[prefix] = f"{basename}-list"
+
+        collections = OrderedDict()
+        namespace = request.resolver_match.namespace
+        for key, url_name in collections_dict.items():
+            if namespace:
+                url_name = namespace + ":" + url_name
+            try:
+                collections[key] = reverse(
+                    url_name,
+                    args=args,
+                    kwargs=kwargs,
+                    request=request,
+                    format=kwargs.get("format", None),
+                )
+            except NoReverseMatch:
+                # Don't bail out if eg. no list routes exist, only detail routes.
+                continue
+
+        return Response(
+            {
+                "links": [
+                    {
+                        "href": request.build_absolute_uri(""),
+                        "rel": "self",
+                        "type": "application/json",
+                        "title": "this document",
+                    },
+                    # {
+                    #     "href": "http://data.example.org/collections.html",
+                    #     "rel": "alternate",
+                    #     "type": "text/html",
+                    #     "title": "this document as HTML",
+                    # },
+                    # {
+                    #     "href": "http://schemas.example.org/1.0/buildings.xsd",
+                    #     "rel": "describedBy",
+                    #     "type": "application/xml",
+                    #     "title": "GML application schema for Acme Corporation building data",
+                    # },
+                    # {
+                    #     "href": "http://download.example.org/buildings.gpkg",
+                    #     "rel": "enclosure",
+                    #     "type": "application/geopackage+sqlite3",
+                    #     "title": "Bulk download (GeoPackage)",
+                    #     "length": 472546,
+                    # },
+                ],
+                "collections": [
+                    {
+                        "id": key,
+                        "title": key,
+                        "description": "?",
+                        "extent": {
+                            "spatial": {"bbox": [[7.01, 50.63, 7.22, 50.78]]},
+                            "temporal": {"interval": [["2010-02-15T12:34:56Z", None]]},
+                        },
+                        "links": [
+                            {
+                                "href": url,
+                                "rel": "items",
+                                "type": "application/geo+json",
+                                "title": key,
+                            },
+                            # {
+                            #     "href": "http://data.example.org/collections/buildings/items.html",
+                            #     "rel": "items",
+                            #     "type": "text/html",
+                            #     "title": "Buildings",
+                            # },
+                            # {
+                            #     "href": "https://creativecommons.org/publicdomain/zero/1.0/",
+                            #     "rel": "license",
+                            #     "type": "text/html",
+                            #     "title": "CC0-1.0",
+                            # },
+                            # {
+                            #     "href": "https://creativecommons.org/publicdomain/zero/1.0/rdf",
+                            #     "rel": "license",
+                            #     "type": "application/rdf+xml",
+                            #     "title": "CC0-1.0",
+                            # },
+                        ],
+                    }
+                    for key, url in collections.items()
+                ],
+            }
+        )

--- a/django_wfs3/views.py
+++ b/django_wfs3/views.py
@@ -101,7 +101,7 @@ class CollectionsView(routers.APIRootView):
                 "description": "?",
                 "extent": {
                     "spatial": {"bbox": extents},
-                    "crs": crs,
+                    # "crs": crs,  # TODO : doesn't work yet
                 },
                 "links": [
                     {

--- a/django_wfs3/views.py
+++ b/django_wfs3/views.py
@@ -14,7 +14,7 @@ from rest_framework.settings import api_settings
 from rest_framework.urlpatterns import format_suffix_patterns
 
 
-class WFS3RootView(views.APIView):
+class RootView(views.APIView):
     """WFS3 index view.
 
     This is currently more or less static
@@ -103,25 +103,6 @@ class CollectionsView(routers.APIRootView):
                         "type": "application/json",
                         "title": "this document",
                     },
-                    # {
-                    #     "href": "http://data.example.org/collections.html",
-                    #     "rel": "alternate",
-                    #     "type": "text/html",
-                    #     "title": "this document as HTML",
-                    # },
-                    # {
-                    #     "href": "http://schemas.example.org/1.0/buildings.xsd",
-                    #     "rel": "describedBy",
-                    #     "type": "application/xml",
-                    #     "title": "GML application schema for Acme Corporation building data",
-                    # },
-                    # {
-                    #     "href": "http://download.example.org/buildings.gpkg",
-                    #     "rel": "enclosure",
-                    #     "type": "application/geopackage+sqlite3",
-                    #     "title": "Bulk download (GeoPackage)",
-                    #     "length": 472546,
-                    # },
                 ],
                 "collections": [
                     {
@@ -139,24 +120,6 @@ class CollectionsView(routers.APIRootView):
                                 "type": "application/geo+json",
                                 "title": key,
                             },
-                            # {
-                            #     "href": "http://data.example.org/collections/buildings/items.html",
-                            #     "rel": "items",
-                            #     "type": "text/html",
-                            #     "title": "Buildings",
-                            # },
-                            # {
-                            #     "href": "https://creativecommons.org/publicdomain/zero/1.0/",
-                            #     "rel": "license",
-                            #     "type": "text/html",
-                            #     "title": "CC0-1.0",
-                            # },
-                            # {
-                            #     "href": "https://creativecommons.org/publicdomain/zero/1.0/rdf",
-                            #     "rel": "license",
-                            #     "type": "application/rdf+xml",
-                            #     "title": "CC0-1.0",
-                            # },
                         ],
                     }
                     for key, url in collections.items()

--- a/geomapshark/settings.py
+++ b/geomapshark/settings.py
@@ -373,7 +373,7 @@ REST_FRAMEWORK = {
         # TODO : remove this once OAuth2 settings from qgis are clear
         "rest_framework.authentication.BasicAuthentication",
     ),
-    'DEFAULT_PAGINATION_CLASS': 'django_wfs3.pagination.CustomPagination',
+    "DEFAULT_PAGINATION_CLASS": "django_wfs3.pagination.CustomPagination",
 }
 
 WFS3_TITLE = "OGC API Features - Geocity"

--- a/geomapshark/settings.py
+++ b/geomapshark/settings.py
@@ -370,6 +370,8 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "oauth2_provider.contrib.rest_framework.OAuth2Authentication",
         "rest_framework.authentication.SessionAuthentication",
+        # TODO : remove this once OAuth2 settings from qgis are clear
+        "rest_framework.authentication.BasicAuthentication",
     ),
     'DEFAULT_PAGINATION_CLASS': 'django_wfs3.pagination.CustomPagination',
     'PAGE_SIZE': 3,

--- a/geomapshark/settings.py
+++ b/geomapshark/settings.py
@@ -374,5 +374,4 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.BasicAuthentication",
     ),
     'DEFAULT_PAGINATION_CLASS': 'django_wfs3.pagination.CustomPagination',
-    'PAGE_SIZE': 3,
 }

--- a/geomapshark/settings.py
+++ b/geomapshark/settings.py
@@ -370,5 +370,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "oauth2_provider.contrib.rest_framework.OAuth2Authentication",
         "rest_framework.authentication.SessionAuthentication",
-    )
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'django_wfs3.pagination.CustomPagination',
+    'PAGE_SIZE': 3,
 }

--- a/geomapshark/settings.py
+++ b/geomapshark/settings.py
@@ -375,3 +375,6 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PAGINATION_CLASS': 'django_wfs3.pagination.CustomPagination',
 }
+
+WFS3_TITLE = "OGC API Features - Geocity"
+WFS3_DESCRIPTION = "Point d'accès OGC API Features aux données Geocity."

--- a/geomapshark/urls.py
+++ b/geomapshark/urls.py
@@ -11,6 +11,7 @@ from rest_framework import routers
 from accounts.geomapfish.provider import GeomapfishProvider
 from permits import api
 from permits import views as permits_views
+from django_wfs3.routers import WFS3Router
 
 from . import views
 
@@ -31,6 +32,9 @@ router.register(r"events", api.PermitRequestGeoTimeViewSet, "events")
 router.register(r"front-config", api.GeocityViewConfigViewSet, "front-config")
 router.register(r"permits", api.PermitRequestViewSet, "permits")
 
+
+wfs3_router = WFS3Router()
+wfs3_router.register(r"permits", api.PermitRequestViewSet, "permits")
 
 # Django-configuration
 urlpatterns = [
@@ -113,6 +117,7 @@ urlpatterns += [
     path("permitauthoredit/", views.permit_author_edit, name="permit_author_edit"),
     path("account/", include("django.contrib.auth.urls")),
     path("rest/", include(router.urls)),  # Django-rest urls
+    path("wfs3/", include(wfs3_router.urls)),  # Django-rest urls
     path("admin/", admin.site.urls),
     path("oauth/", include("oauth2_provider.urls", namespace="oauth2_provider")),
 ]

--- a/geomapshark/urls.py
+++ b/geomapshark/urls.py
@@ -11,7 +11,7 @@ from rest_framework import routers
 from accounts.geomapfish.provider import GeomapfishProvider
 from permits import api
 from permits import views as permits_views
-import django_wfs3.urls
+from django_wfs3.urls import wfs3_router
 
 from . import views
 
@@ -113,7 +113,7 @@ urlpatterns += [
     path("permitauthoredit/", views.permit_author_edit, name="permit_author_edit"),
     path("account/", include("django.contrib.auth.urls")),
     path("rest/", include(router.urls)),  # Django-rest urls
-    path("wfs3/", include(django_wfs3.urls)),  # Django-rest urls
+    path("wfs3/", include(wfs3_router.urls)),  # Django-rest urls
     path("admin/", admin.site.urls),
     path("oauth/", include("oauth2_provider.urls", namespace="oauth2_provider")),
 ]

--- a/geomapshark/urls.py
+++ b/geomapshark/urls.py
@@ -11,7 +11,7 @@ from rest_framework import routers
 from accounts.geomapfish.provider import GeomapfishProvider
 from permits import api
 from permits import views as permits_views
-from django_wfs3.routers import WFS3Router
+import django_wfs3.urls
 
 from . import views
 
@@ -31,10 +31,6 @@ router = routers.DefaultRouter()
 router.register(r"events", api.PermitRequestGeoTimeViewSet, "events")
 router.register(r"front-config", api.GeocityViewConfigViewSet, "front-config")
 router.register(r"permits", api.PermitRequestViewSet, "permits")
-
-
-wfs3_router = WFS3Router()
-wfs3_router.register(r"permits", api.PermitRequestViewSet, "permits")
 
 # Django-configuration
 urlpatterns = [
@@ -117,7 +113,7 @@ urlpatterns += [
     path("permitauthoredit/", views.permit_author_edit, name="permit_author_edit"),
     path("account/", include("django.contrib.auth.urls")),
     path("rest/", include(router.urls)),  # Django-rest urls
-    path("wfs3/", include(wfs3_router.urls)),  # Django-rest urls
+    path("wfs3/", include(django_wfs3.urls)),  # Django-rest urls
     path("admin/", admin.site.urls),
     path("oauth/", include("oauth2_provider.urls", namespace="oauth2_provider")),
 ]

--- a/permits/api.py
+++ b/permits/api.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import User
 from django.db.models import CharField, F, Prefetch, Q
 from rest_framework import viewsets
 from rest_framework.permissions import BasePermission, IsAuthenticated
+from django_wfs3.mixins import WFS3DescribeModelMixin
 
 from . import geoservices, models, serializers, services
 from constance import config
@@ -133,7 +134,7 @@ class BlockRequesterUserPermission(BasePermission):
             return user.get_all_permissions()
 
 
-class PermitRequestViewSet(viewsets.ReadOnlyModelViewSet):
+class PermitRequestViewSet(WFS3DescribeModelMixin, viewsets.ReadOnlyModelViewSet):
     """
     Permit request endpoint Usage:
         1.- /rest/permits/?permit_request_id=1
@@ -144,6 +145,7 @@ class PermitRequestViewSet(viewsets.ReadOnlyModelViewSet):
 
     serializer_class = serializers.PermitRequestPrintSerializer
     permission_classes = [BlockRequesterUserPermission]
+
 
     def get_queryset(self):
         """

--- a/permits/api.py
+++ b/permits/api.py
@@ -5,7 +5,12 @@ from django.contrib.auth.decorators import (
 )
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.gis.geos.collections import GeometryCollection, MultiLineString, MultiPoint, MultiPolygon
+from django.contrib.gis.geos.collections import (
+    GeometryCollection,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+)
 from django.db.models import CharField, F, Prefetch, Q
 from rest_framework import viewsets
 from rest_framework.permissions import BasePermission, IsAuthenticated
@@ -136,7 +141,9 @@ class BlockRequesterUserPermission(BasePermission):
             return user.get_all_permissions()
 
 
-class PermitRequestViewSet(WFS3DescribeModelViewSetMixin, viewsets.ReadOnlyModelViewSet):
+class PermitRequestViewSet(
+    WFS3DescribeModelViewSetMixin, viewsets.ReadOnlyModelViewSet
+):
     """
     Permit request endpoint Usage:
         1.- /rest/permits/?permit_request_id=1
@@ -150,9 +157,8 @@ class PermitRequestViewSet(WFS3DescribeModelViewSetMixin, viewsets.ReadOnlyModel
 
     wfs3_title = "Permis"
     wfs3_description = "Tous les permis accordés"
-    wfs3_geom_lookup = 'geo_time__geom'  # lookup for the geometry (on the queryset), used to determine bbox
+    wfs3_geom_lookup = "geo_time__geom"  # lookup for the geometry (on the queryset), used to determine bbox
     wfs3_srid = 2056  # TODO : dynamically retrieve this from the above attribute on the queryset
-
 
     def get_queryset(self):
         """
@@ -231,11 +237,13 @@ class PermitRequestPointViewSet(PermitRequestViewSet):
         geo_envelop = serializers.PermitRequestGeoTimeGeoJSONSerializer(
             source="geo_time",
             read_only=True,
-            extract_geom=serializers.PermitRequestGeoTimeGeoJSONSerializer.EXTRACT_POINTS
+            extract_geom=serializers.PermitRequestGeoTimeGeoJSONSerializer.EXTRACT_POINTS,
         )
 
     wfs3_title = f"{PermitRequestViewSet.wfs3_title} (points)"
-    wfs3_description = f"{PermitRequestViewSet.wfs3_description} (géomtries filtrées par type points)"
+    wfs3_description = (
+        f"{PermitRequestViewSet.wfs3_description} (géomtries filtrées par type points)"
+    )
     serializer_class = PermitRequestViewSetSerializerPoint
 
 
@@ -246,11 +254,13 @@ class PermitRequestLineViewSet(PermitRequestViewSet):
         geo_envelop = serializers.PermitRequestGeoTimeGeoJSONSerializer(
             source="geo_time",
             read_only=True,
-            extract_geom=serializers.PermitRequestGeoTimeGeoJSONSerializer.EXTRACT_LINES
+            extract_geom=serializers.PermitRequestGeoTimeGeoJSONSerializer.EXTRACT_LINES,
         )
 
     wfs3_title = f"{PermitRequestViewSet.wfs3_title} (lines)"
-    wfs3_description = f"{PermitRequestViewSet.wfs3_description} (géomtries filtrées par type lines)"
+    wfs3_description = (
+        f"{PermitRequestViewSet.wfs3_description} (géomtries filtrées par type lines)"
+    )
     serializer_class = PermitRequestViewSetSerializerLine
 
 
@@ -261,9 +271,11 @@ class PermitRequestPolyViewSet(PermitRequestViewSet):
         geo_envelop = serializers.PermitRequestGeoTimeGeoJSONSerializer(
             source="geo_time",
             read_only=True,
-            extract_geom=serializers.PermitRequestGeoTimeGeoJSONSerializer.EXTRACT_POLYS
+            extract_geom=serializers.PermitRequestGeoTimeGeoJSONSerializer.EXTRACT_POLYS,
         )
 
     wfs3_title = f"{PermitRequestViewSet.wfs3_title} (polys)"
-    wfs3_description = f"{PermitRequestViewSet.wfs3_description} (géomtries filtrées par type polys)"
+    wfs3_description = (
+        f"{PermitRequestViewSet.wfs3_description} (géomtries filtrées par type polys)"
+    )
     serializer_class = PermitRequestViewSetSerializerPoly

--- a/permits/api.py
+++ b/permits/api.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.db.models import CharField, F, Prefetch, Q
 from rest_framework import viewsets
 from rest_framework.permissions import BasePermission, IsAuthenticated
-from django_wfs3.mixins import WFS3DescribeModelMixin
+from django_wfs3.mixins import WFS3DescribeModelViewSetMixin
 
 from . import geoservices, models, serializers, services
 from constance import config
@@ -134,7 +134,7 @@ class BlockRequesterUserPermission(BasePermission):
             return user.get_all_permissions()
 
 
-class PermitRequestViewSet(WFS3DescribeModelMixin, viewsets.ReadOnlyModelViewSet):
+class PermitRequestViewSet(WFS3DescribeModelViewSetMixin, viewsets.ReadOnlyModelViewSet):
     """
     Permit request endpoint Usage:
         1.- /rest/permits/?permit_request_id=1
@@ -145,6 +145,11 @@ class PermitRequestViewSet(WFS3DescribeModelMixin, viewsets.ReadOnlyModelViewSet
 
     serializer_class = serializers.PermitRequestPrintSerializer
     permission_classes = [BlockRequesterUserPermission]
+
+    wfs3_title = "Permis"
+    wfs3_description = "Tous les permis accordés"
+    wfs3_geom_lookup = 'geo_time__geom'  # lookup for the geometry (on the queryset), used to determine bbox
+    wfs3_srid = 2056  # TODO : dynamically retrieve this from the above attribute on the queryset
 
 
     def get_queryset(self):

--- a/permits/api.py
+++ b/permits/api.py
@@ -229,6 +229,7 @@ class PermitRequestViewSet(
 
         return qs
 
+
 # TODO : factorize these three classes together using a factory
 class PermitRequestPointViewSet(PermitRequestViewSet):
     """Same as PermitRequestViewSet, but returns MultiPoints instead of the bounding box"""
@@ -252,6 +253,7 @@ class PermitRequestPointViewSet(PermitRequestViewSet):
         self.request.GET["geom_type"] = "points"
         return super().get_queryset()
 
+
 # TODO : factorize these three classes together using a factory
 class PermitRequestLineViewSet(PermitRequestViewSet):
     """Same as PermitRequestViewSet, but returns MultiLines instead of the bounding box"""
@@ -274,6 +276,7 @@ class PermitRequestLineViewSet(PermitRequestViewSet):
         self.request.GET = self.request.GET.copy()
         self.request.GET["geom_type"] = "lines"
         return super().get_queryset()
+
 
 # TODO : factorize these three classes together using a factory
 class PermitRequestPolyViewSet(PermitRequestViewSet):

--- a/permits/api.py
+++ b/permits/api.py
@@ -229,7 +229,7 @@ class PermitRequestViewSet(
 
         return qs
 
-
+# TODO : factorize these three classes together using a factory
 class PermitRequestPointViewSet(PermitRequestViewSet):
     """Same as PermitRequestViewSet, but returns MultiPoints instead of the bounding box"""
 
@@ -246,7 +246,13 @@ class PermitRequestPointViewSet(PermitRequestViewSet):
     )
     serializer_class = PermitRequestViewSetSerializerPoint
 
+    def get_queryset(self):
+        # Inject the geometry filter
+        self.request.GET = self.request.GET.copy()
+        self.request.GET["geom_type"] = "points"
+        return super().get_queryset()
 
+# TODO : factorize these three classes together using a factory
 class PermitRequestLineViewSet(PermitRequestViewSet):
     """Same as PermitRequestViewSet, but returns MultiLines instead of the bounding box"""
 
@@ -263,7 +269,13 @@ class PermitRequestLineViewSet(PermitRequestViewSet):
     )
     serializer_class = PermitRequestViewSetSerializerLine
 
+    def get_queryset(self):
+        # Inject the geometry filter
+        self.request.GET = self.request.GET.copy()
+        self.request.GET["geom_type"] = "lines"
+        return super().get_queryset()
 
+# TODO : factorize these three classes together using a factory
 class PermitRequestPolyViewSet(PermitRequestViewSet):
     """Same as PermitRequestViewSet, but returns MultiPolygons instead of the bounding box"""
 
@@ -279,3 +291,9 @@ class PermitRequestPolyViewSet(PermitRequestViewSet):
         f"{PermitRequestViewSet.wfs3_description} (géomtries filtrées par type polys)"
     )
     serializer_class = PermitRequestViewSetSerializerPoly
+
+    def get_queryset(self):
+        # Inject the geometry filter
+        self.request.GET = self.request.GET.copy()
+        self.request.GET["geom_type"] = "polygons"
+        return super().get_queryset()

--- a/permits/geoservices.py
+++ b/permits/geoservices.py
@@ -49,7 +49,7 @@ class GeomStAsText(GeomOutputGeoFunc):
 
 class JoinGeometries(Aggregate):
     name = "joined_geometries"
-    template = "ST_SetSRID(ST_Extent(%(expressions)s), 2056)"
+    template = "ST_SetSRID(ST_Expand(ST_Extent(%(expressions)s), 1), 2056)"
     allow_distinct = False
 
 

--- a/permits/geoservices.py
+++ b/permits/geoservices.py
@@ -51,3 +51,18 @@ class JoinGeometries(Aggregate):
     name = "joined_geometries"
     template = "ST_SetSRID(ST_Extent(%(expressions)s), 2056)"
     allow_distinct = False
+
+
+class ExtractPoints(Aggregate):
+    name = "extracted_points"
+    template = "ST_CollectionExtract(ST_Collect(%(expressions)s), 1)"
+
+
+class ExtractLines(Aggregate):
+    name = "extracted_lines"
+    template = "ST_CollectionExtract(ST_Collect(%(expressions)s), 2)"
+
+
+class ExtractPolys(Aggregate):
+    name = "extracted_polys"
+    template = "ST_CollectionExtract(ST_Collect(%(expressions)s), 3)"

--- a/permits/serializers.py
+++ b/permits/serializers.py
@@ -2,6 +2,7 @@ import json
 
 from collections import OrderedDict
 from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.db.models.functions import AsGeoJSON
 from django.db.models import Max, Min
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
@@ -251,7 +252,7 @@ class PermitRequestGeoTimeGeoJSONSerializer(serializers.Serializer):
             result = {"properties": {}}
             if not aggregated_geotime_qs["singlegeom"]:
                 # Insert empty geometry if there is none
-                result["geometry"] = {"type": "Point", "coordinates": []}
+                result["geometry"] = None
             else:
                 result["geometry"] = json.loads(
                     GEOSGeometry(aggregated_geotime_qs["singlegeom"]).json

--- a/permits/urls.py
+++ b/permits/urls.py
@@ -1,6 +1,11 @@
 from django.urls import include, path
 
+from django_wfs3.urls import wfs3_router
+
 from . import api, geoviews, views
+
+
+wfs3_router.register(r"permits", api.PermitRequestViewSet, "permits")
 
 app_name = "permits"
 

--- a/permits/urls.py
+++ b/permits/urls.py
@@ -6,6 +6,12 @@ from . import api, geoviews, views
 
 
 wfs3_router.register(r"permits", api.PermitRequestViewSet, "permits")
+wfs3_router.register(r"geotime", api.PermitRequestGeoTimeViewSet, "geotime")
+wfs3_router.register(r"geotime_point", api.PermitRequestGeoTimePointViewSet, "geotime_point")
+wfs3_router.register(r"geotime_line", api.PermitRequestGeoTimeLineViewSet, "geotime_line")
+wfs3_router.register(r"geotime_poly", api.PermitRequestGeoTimePolyViewSet, "geotime_poly")
+# wfs3_router.register(r"permits-geotime", api.PermitRequestGeoTimeViewSet, "permits_geotime")
+# wfs3_router.register(r"simple", api.SimpleGeoViewSet, "simple")
 
 app_name = "permits"
 

--- a/permits/urls.py
+++ b/permits/urls.py
@@ -10,8 +10,6 @@ wfs3_router.register(r"geotime", api.PermitRequestGeoTimeViewSet, "geotime")
 wfs3_router.register(r"geotime_point", api.PermitRequestGeoTimePointViewSet, "geotime_point")
 wfs3_router.register(r"geotime_line", api.PermitRequestGeoTimeLineViewSet, "geotime_line")
 wfs3_router.register(r"geotime_poly", api.PermitRequestGeoTimePolyViewSet, "geotime_poly")
-# wfs3_router.register(r"permits-geotime", api.PermitRequestGeoTimeViewSet, "permits_geotime")
-# wfs3_router.register(r"simple", api.SimpleGeoViewSet, "simple")
 
 app_name = "permits"
 

--- a/permits/urls.py
+++ b/permits/urls.py
@@ -6,10 +6,9 @@ from . import api, geoviews, views
 
 
 wfs3_router.register(r"permits", api.PermitRequestViewSet, "permits")
-wfs3_router.register(r"geotime", api.PermitRequestGeoTimeViewSet, "geotime")
-wfs3_router.register(r"geotime_point", api.PermitRequestGeoTimePointViewSet, "geotime_point")
-wfs3_router.register(r"geotime_line", api.PermitRequestGeoTimeLineViewSet, "geotime_line")
-wfs3_router.register(r"geotime_poly", api.PermitRequestGeoTimePolyViewSet, "geotime_poly")
+wfs3_router.register(r"permits_point", api.PermitRequestPointViewSet, "permit_point")
+wfs3_router.register(r"permits_line", api.PermitRequestLineViewSet, "permit_line")
+wfs3_router.register(r"permits_poly", api.PermitRequestPolyViewSet, "permit_poly")
 
 app_name = "permits"
 

--- a/requirements.in
+++ b/requirements.in
@@ -33,3 +33,6 @@ filetype
 django-oauth-toolkit
 # Open authentication consumer
 django-allauth
+# django_wfs3 -> djangorestframework (optional for openapi schema generation, see https://www.django-rest-framework.org/api-guide/schemas/#install-dependencies)
+pyyaml
+uritemplate

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,6 +154,8 @@ tablib==3.0.0
     # via -r requirements.in
 tomli==1.2.1
     # via pep517
+uritemplate==3.0.1
+    # via -r requirements.in
 urllib3==1.26.7
     # via requests
 webencodings==0.5.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -272,6 +272,8 @@ traitlets==5.0.5
     #   matplotlib-inline
 typed-ast==1.4.3
     # via black
+uritemplate==3.0.1
+    # via -r requirements.txt
 urllib3==1.26.7
     # via
     #   -r requirements.txt


### PR DESCRIPTION
This is the WIP implementation for WFS3 (aka OGC Features API) for Django applied to Geocity.

Please see `django_wfs3/README.md` for more info on implementation.

![geocitywfs3](https://user-images.githubusercontent.com/1894106/135130336-70a7945b-b676-44ce-a490-52cc41181f03.gif)

It's not ready yet, but opening this PR already so you can review and see if it takes the desired direction.

Roadmap :
- [x] basic implementation
- [x] working readonly endpoints 
  - [x] PermitRequestViewSet (incl. subclasses for point/line/poly only geometries so they can load in QGIS)
  - [x] PermitRequestGeoTimeViewSet
- [ ] fix CRS in QGIS (seems CRS is simply ignored - do we have a working example, or is it an issue with QGIS ?)
- [x] various other fixes (see TODO in code)
- [x] test with oauth2 (it should work already, but unsure how this must be configured from QGIS)
