### PR TITLE
Fix WFS3 description

### DIFF
--- a/permits/api.py
+++ b/permits/api.py
@@ -256,7 +256,7 @@ def permitRequestViewSetSubsetFactory(geom_type_name):
 
     class ViewSet(PermitRequestViewSet):
         wfs3_title = f"{PermitRequestViewSet.wfs3_title} ({geom_type_name})"
-        wfs3_description = f"{PermitRequestViewSet.wfs3_description} (géométries filtrées par type {geom_type_name})"
+        wfs3_description = f"{PermitRequestViewSet.wfs3_description} (géométries de type {geom_type_name})"
         serializer_class = Serializer
 
         def get_queryset(self):

--- a/permits/api.py
+++ b/permits/api.py
@@ -150,7 +150,7 @@ class PermitRequestViewSet(
     permission_classes = [BlockRequesterUserPermission]
 
     wfs3_title = "Permis"
-    wfs3_description = "Tous les permis accordés"
+    wfs3_description = "Tous les permis"
     wfs3_geom_lookup = "geo_time__geom"  # lookup for the geometry (on the queryset), used to determine bbox
     wfs3_srid = 2056
 

--- a/permits/api.py
+++ b/permits/api.py
@@ -256,7 +256,7 @@ def permitRequestViewSetSubsetFactory(geom_type_name):
 
     class ViewSet(PermitRequestViewSet):
         wfs3_title = f"{PermitRequestViewSet.wfs3_title} ({geom_type_name})"
-        wfs3_description = f"{PermitRequestViewSet.wfs3_description} (géomtries filtrées par type {geom_type_name})"
+        wfs3_description = f"{PermitRequestViewSet.wfs3_description} (géométries filtrées par type {geom_type_name})"
         serializer_class = Serializer
 
         def get_queryset(self):

--- a/permits/api.py
+++ b/permits/api.py
@@ -149,8 +149,8 @@ class PermitRequestViewSet(
     serializer_class = serializers.PermitRequestPrintSerializer
     permission_classes = [BlockRequesterUserPermission]
 
-    wfs3_title = "Permis"
-    wfs3_description = "Tous les permis"
+    wfs3_title = "Demandes"
+    wfs3_description = "Toutes les demandes"
     wfs3_geom_lookup = "geo_time__geom"  # lookup for the geometry (on the queryset), used to determine bbox
     wfs3_srid = 2056
 


### PR DESCRIPTION
@monodo Tell me what do you think. Here is the result:

![image](https://user-images.githubusercontent.com/4549666/142029574-dddf4f7e-f9c7-4992-b4cb-0e1020acba8d.png)

In an ideal world, il would also rename the `geom_type_name` displayed in title and abstract, but since the keywords are also used as query parameters `geom_type`, it would be confusing to have 2 spellings (and I don't want to break the API).

See each commits for detailed information on changes.