### PR TITLE
Migrate to PG13.

### DIFF
--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -45,7 +45,7 @@ services:
             - PREFIX_URL
 
     postgres:
-        image: postgis/postgis:14-3.2
+        image: postgis/postgis:13-3.2
         restart: unless-stopped
         environment:
             - POSTGRES_USER=${PGUSER}

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -45,7 +45,7 @@ services:
             - PREFIX_URL
 
     postgres:
-        image: camptocamp/postgres:11
+        image: postgis/postgis:14-3.2
         restart: unless-stopped
         environment:
             - POSTGRES_USER=${PGUSER}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -48,7 +48,7 @@ services:
             - PREFIX_URL
 
     postgres:
-        image: postgis/postgis:14-3.2
+        image: postgis/postgis:13-3.2
         restart: unless-stopped
         environment:
             - POSTGRES_USER=${PGUSER}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -48,7 +48,7 @@ services:
             - PREFIX_URL
 
     postgres:
-        image: camptocamp/postgres:11
+        image: postgis/postgis:14-3.2
         restart: unless-stopped
         environment:
             - POSTGRES_USER=${PGUSER}


### PR DESCRIPTION
Migrates to PG13 in both the development and the demo Compose files.

You will probably have to `down -v` if you have a previous version of a PG database running in order to set it up with the newest version. 