### PR TITLE
YC-225: Change order of WorksObjectType string value

### DIFF
--- a/permits/models.py
+++ b/permits/models.py
@@ -814,7 +814,7 @@ class WorksObjectType(models.Model):
         unique_together = [("works_type", "works_object")]
 
     def __str__(self):
-        return "{} ({})".format(self.works_object.name, self.works_type.name)
+        return "{}: {}".format(self.works_type.name, self.works_object.name)
 
     @property
     def has_geometry(self):


### PR DESCRIPTION
Fix https://jira.liip.ch/browse/YC-225

Since the value is also displayed in the resumé, I didn't used the `>` but `:` (`>` was good only for navigation purpose).

Should we display it `foo: bar` or `foo : bar`?

Please review.