### PR TITLE
YC-563: Display prolongation tab only if request can be prolonged

### DIFF
--- a/permits/forms.py
+++ b/permits/forms.py
@@ -1241,7 +1241,7 @@ class PermitRequestProlongationForm(forms.ModelForm):
                 "minDate": (datetime.today()).strftime("%Y/%m/%d"),
             }
         ).start_of("event days"),
-        help_text="Cliquer sur le champ et selectionner la nouvelle date de fin planifiée",
+        help_text="Cliquer sur le champ et sélectionner la nouvelle date de fin planifiée",
     )
 
     class Meta:

--- a/permits/services.py
+++ b/permits/services.py
@@ -1271,7 +1271,7 @@ def get_actions_for_administrative_entity(permit_request):
 
     actions = models.ACTIONS
 
-    # Statuses for which a given action should be availble
+    # Statuses for which a given action should be available
     required_statuses_for_actions = {
         "amend": list(models.PermitRequest.AMENDABLE_STATUSES),
         "request_validation": [models.PermitRequest.STATUS_AWAITING_VALIDATION],

--- a/permits/templates/permits/_permit_request_actions.html
+++ b/permits/templates/permits/_permit_request_actions.html
@@ -64,7 +64,7 @@
 
       {% endif %}
 
-      {% if forms.prolong and permit_request.can_be_prolonged %}
+      {% if forms.prolong and prolongation_enabled %}
 
           <li class="nav-item">
               <a class="btn btn-primary btn-action nav-link{% if active_form == 'prolong' %} active{% endif %}" id="classify-tab" data-toggle="tab" href="#prolong" role="tab" aria-controls="prolong" aria-selected="{% if active_form == 'prolong' %}true{% else %}false{% endif %}">
@@ -204,23 +204,22 @@
             </div>
         {% endif %}
 
-        {% if forms.prolong and permit_request.can_be_prolonged %}
+        {% if forms.prolong and prolongation_enabled %}
         <div class="tab-pane{% if active_form == 'prolong' %} show active{% endif  %}" id="prolong" role="tabpanel" aria-labelledby="prolong-tab">
+            <form method="post">
+                {% csrf_token %}
+                {{ forms.prolong.media }}
+                {% if not forms.prolong.prolongation_date.value %}
+                <small class="form-text text-muted mb-3">{% trans "Aucune prolongation n'a été demandée par l'auteur-e" %}</small>
+                {% endif %}
+                {% bootstrap_form forms.prolong layout='horizontal' %}
 
-        <form method="post">
-            {% csrf_token %}
-            {{ forms.prolong.media }}
-            {% if not forms.prolong.prolongation_date.value %}
-            <small class="form-text text-muted mb-3">{% trans "Aucune prolongation n'a été demandée par l'auteur-e" %}</small>
-            {% endif %}
-            {% bootstrap_form forms.prolong layout='horizontal' %}
-
-            <div class="text-right">
-            <input name="action" type="hidden" value="prolong">
-            <button class="btn btn-primary" {% if forms.prolong.disabled %}disabled{% endif %}>{% trans "Enregistrer" %}</button>
-            <button class="btn btn-primary" name="save_continue" {% if forms.prolong.disabled %}disabled{% endif %}>{% trans "Enregistrer et continuer les modifications" %}</button>
-            </div>
-        </form>
+                <div class="text-right">
+                    <input name="action" type="hidden" value="prolong">
+                    <button class="btn btn-primary" {% if forms.prolong.disabled %}disabled{% endif %}>{% trans "Enregistrer" %}</button>
+                    <button class="btn btn-primary" name="save_continue" {% if forms.prolong.disabled %}disabled{% endif %}>{% trans "Enregistrer et continuer les modifications" %}</button>
+                </div>
+            </form>
         </div>
         {% endif %}
 

--- a/permits/templates/permits/_permit_request_actions.html
+++ b/permits/templates/permits/_permit_request_actions.html
@@ -64,7 +64,7 @@
 
       {% endif %}
 
-      {% if forms.prolong %}
+      {% if forms.prolong and permit_request.can_be_prolonged %}
 
           <li class="nav-item">
               <a class="btn btn-primary btn-action nav-link{% if active_form == 'prolong' %} active{% endif %}" id="classify-tab" data-toggle="tab" href="#prolong" role="tab" aria-controls="prolong" aria-selected="{% if active_form == 'prolong' %}true{% else %}false{% endif %}">
@@ -204,7 +204,7 @@
             </div>
         {% endif %}
 
-        {% if forms.prolong %}
+        {% if forms.prolong and permit_request.can_be_prolonged %}
         <div class="tab-pane{% if active_form == 'prolong' %} show active{% endif  %}" id="prolong" role="tabpanel" aria-labelledby="prolong-tab">
 
         <form method="post">
@@ -223,6 +223,7 @@
         </form>
         </div>
         {% endif %}
+
       </div>
     </div>
   </div>

--- a/permits/tests/test_a_permit_request.py
+++ b/permits/tests/test_a_permit_request.py
@@ -1893,11 +1893,8 @@ class PermitRequestProlongationTestCase(LoggedInUserMixin, TestCase):
         permit_request = factories.PermitRequestFactory(
             status=models.PermitRequest.STATUS_APPROVED,
         )
-
         permit_request.works_object_types.set([self.wot_prolongable_with_date])
-
         permit_request.administrative_entity.departments.set([self.department])
-
         self.client.login(username=self.secretariat, password="password")
 
         response = self.client.get(
@@ -1906,7 +1903,6 @@ class PermitRequestProlongationTestCase(LoggedInUserMixin, TestCase):
                 kwargs={"permit_request_id": permit_request.pk},
             )
         )
-
         parser = get_parser(response.content)
 
         self.assertEqual(response.status_code, 200)
@@ -1921,13 +1917,10 @@ class PermitRequestProlongationTestCase(LoggedInUserMixin, TestCase):
         permit_request = factories.PermitRequestFactory(
             status=models.PermitRequest.STATUS_APPROVED,
         )
-
         permit_request.works_object_types.set(
             [self.wot_prolongable_with_date, self.wot_normal]
         )
-
         permit_request.administrative_entity.departments.set([self.department])
-
         self.client.login(username=self.secretariat, password="password")
 
         response = self.client.get(
@@ -1936,7 +1929,6 @@ class PermitRequestProlongationTestCase(LoggedInUserMixin, TestCase):
                 kwargs={"permit_request_id": permit_request.pk},
             )
         )
-
         parser = get_parser(response.content)
 
         self.assertEqual(response.status_code, 200)
@@ -1951,11 +1943,8 @@ class PermitRequestProlongationTestCase(LoggedInUserMixin, TestCase):
         permit_request = factories.PermitRequestFactory(
             status=models.PermitRequest.STATUS_APPROVED,
         )
-
         permit_request.works_object_types.set([self.wot_normal])
-
         permit_request.administrative_entity.departments.set([self.department])
-
         self.client.login(username=self.secretariat, password="password")
 
         response = self.client.get(
@@ -1964,7 +1953,6 @@ class PermitRequestProlongationTestCase(LoggedInUserMixin, TestCase):
                 kwargs={"permit_request_id": permit_request.pk},
             )
         )
-
         parser = get_parser(response.content)
 
         self.assertEqual(response.status_code, 200)

--- a/permits/tests/test_a_permit_request.py
+++ b/permits/tests/test_a_permit_request.py
@@ -1464,7 +1464,7 @@ class PermitRequestProlongationTestCase(LoggedInUserMixin, TestCase):
         title = parser.find("h3", string="Demande de prolongation de permis")
         widget = parser.find(
             "input",
-            title="Cliquer sur le champ et selectionner la nouvelle date de fin planifiée",
+            title="Cliquer sur le champ et sélectionner la nouvelle date de fin planifiée",
         )
         self.assertEqual(1, len(title))
         self.assertEqual("id_prolongation_date", widget.get("id"))

--- a/permits/tests/test_a_permit_request.py
+++ b/permits/tests/test_a_permit_request.py
@@ -1886,6 +1886,92 @@ class PermitRequestProlongationTestCase(LoggedInUserMixin, TestCase):
         self.assertEqual(0, len(action_prolongation_requested))
         self.assertEqual(1, len(action_prolongation_rejected))
 
+    def test_secretariat_can_see_prolongation_buttons_if_wot_has_prolongation_enabled(
+        self,
+    ):
+
+        permit_request = factories.PermitRequestFactory(
+            status=models.PermitRequest.STATUS_APPROVED,
+        )
+
+        permit_request.works_object_types.set([self.wot_prolongable_with_date])
+
+        permit_request.administrative_entity.departments.set([self.department])
+
+        self.client.login(username=self.secretariat, password="password")
+
+        response = self.client.get(
+            reverse(
+                "permits:permit_request_detail",
+                kwargs={"permit_request_id": permit_request.pk},
+            )
+        )
+
+        parser = get_parser(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            len(parser.select(".tab-pane#prolong button")), 2,
+        )
+
+    def test_secretariat_can_see_prolongation_buttons_if_at_least_one_wot_has_prolongation_enabled(
+        self,
+    ):
+
+        permit_request = factories.PermitRequestFactory(
+            status=models.PermitRequest.STATUS_APPROVED,
+        )
+
+        permit_request.works_object_types.set(
+            [self.wot_prolongable_with_date, self.wot_normal]
+        )
+
+        permit_request.administrative_entity.departments.set([self.department])
+
+        self.client.login(username=self.secretariat, password="password")
+
+        response = self.client.get(
+            reverse(
+                "permits:permit_request_detail",
+                kwargs={"permit_request_id": permit_request.pk},
+            )
+        )
+
+        parser = get_parser(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            len(parser.select(".tab-pane#prolong button")), 2,
+        )
+
+    def test_secretariat_cannot_see_prolongation_buttons_if_wot_has_not_prolongation_enabled(
+        self,
+    ):
+
+        permit_request = factories.PermitRequestFactory(
+            status=models.PermitRequest.STATUS_APPROVED,
+        )
+
+        permit_request.works_object_types.set([self.wot_normal])
+
+        permit_request.administrative_entity.departments.set([self.department])
+
+        self.client.login(username=self.secretariat, password="password")
+
+        response = self.client.get(
+            reverse(
+                "permits:permit_request_detail",
+                kwargs={"permit_request_id": permit_request.pk},
+            )
+        )
+
+        parser = get_parser(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            len(parser.select(".tab-pane#prolong button")), 0,
+        )
+
 
 class PermitRequestActorsTestCase(LoggedInUserMixin, TestCase):
     def setUp(self):

--- a/permits/views.py
+++ b/permits/views.py
@@ -13,7 +13,7 @@ from django.contrib.auth.decorators import (
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.core.files.base import ContentFile
 from django.db import transaction
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Sum
 from django.forms import modelformset_factory
 from django.http import (
     Http404,
@@ -228,6 +228,12 @@ class PermitRequestDetailView(View):
             or can_validate_permit_request
             else None
         )
+        prolongation_enabled = (
+            services.get_works_object_type_choices(self.permit_request).aggregate(
+                Sum("works_object_type__permit_duration")
+            )["works_object_type__permit_duration__sum"]
+            is not None
+        )
 
         return {
             **kwargs,
@@ -249,6 +255,7 @@ class PermitRequestDetailView(View):
                 "directives": services.get_permit_request_directives(
                     self.permit_request
                 ),
+                "prolongation_enabled": prolongation_enabled,
             },
         }
 


### PR DESCRIPTION
Fix https://jira.liip.ch/browse/YC-563

Please review and test.

For a reason I don't get, there is no change detected after editing the helper_text:

```
python manage.py makemigrations -n fix_typo
No changes detected
```