### PR TITLE
Fix never displaying directive addtionnal info

### DIFF
--- a/permits/templates/permits/_permit_request_actions.html
+++ b/permits/templates/permits/_permit_request_actions.html
@@ -163,13 +163,12 @@
                 {% if directive_file and directive_description %}
                     {{forloop.counter}}.
                     <span class="directive_description">{{ directive_description }}</span> -
-                    {% if directive_file %}
                         <i class="fa fa-download" aria-hidden="true"></i>
                         <a class="directive_file" href="{{ directive_file.url }}" target="_blank" rel="noreferrer">
                         {% trans "Télécharger le fichier" %}
-                        </a>
-                    {% endif %} - <span class="additional_information">{{ additional_information }}</span>
+                        </a><br>
                 {% endif %}
+                <span class="additional_information">{{ additional_information }}</span>
             </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
Fix something that was never working... (when only `additional_information` is set)

I used the same logical as in https://github.com/yverdon/geocity/blob/main/permits/templates/permits/permit_request_submit.html#L28-L40