### PR TITLE
Add some other field types in search

### DIFF
--- a/permits/models.py
+++ b/permits/models.py
@@ -55,9 +55,16 @@ ACTOR_TYPE_CHOICES = (
 )
 
 # Input types
-INPUT_TYPE_LIST_SINGLE = "list_single"
+INPUT_TYPE_ADDRESS = "address"
+INPUT_TYPE_CHECKBOX = "checkbox"
+INPUT_TYPE_DATE = "date"
+INPUT_TYPE_FILE = "file"
 INPUT_TYPE_LIST_MULTIPLE = "list_multiple"
+INPUT_TYPE_LIST_SINGLE = "list_single"
+INPUT_TYPE_NUMBER = "number"
 INPUT_TYPE_REGEX = "regex"
+INPUT_TYPE_TEXT = "text"
+INPUT_TYPE_TITLE = "title"
 
 # Actions
 ACTION_AMEND = "amend"
@@ -874,16 +881,17 @@ class WorksObject(models.Model):
 
 
 class WorksObjectProperty(models.Model):
-    INPUT_TYPE_TEXT = "text"
-    INPUT_TYPE_CHECKBOX = "checkbox"
-    INPUT_TYPE_NUMBER = "number"
-    INPUT_TYPE_FILE = "file"
-    INPUT_TYPE_ADDRESS = "address"
-    INPUT_TYPE_DATE = "date"
+    INPUT_TYPE_TEXT = INPUT_TYPE_TEXT
+    INPUT_TYPE_CHECKBOX = INPUT_TYPE_CHECKBOX
+    INPUT_TYPE_NUMBER = INPUT_TYPE_NUMBER
+    INPUT_TYPE_FILE = INPUT_TYPE_FILE
+    INPUT_TYPE_ADDRESS = INPUT_TYPE_ADDRESS
+    INPUT_TYPE_DATE = INPUT_TYPE_DATE
     INPUT_TYPE_REGEX = INPUT_TYPE_REGEX
     INPUT_TYPE_LIST_SINGLE = INPUT_TYPE_LIST_SINGLE
     INPUT_TYPE_LIST_MULTIPLE = INPUT_TYPE_LIST_MULTIPLE
-    INPUT_TYPE_TITLE = "title"
+    INPUT_TYPE_TITLE = INPUT_TYPE_TITLE
+    # The choices are sorted according to their values
     INPUT_TYPE_CHOICES = (
         (INPUT_TYPE_ADDRESS, _("Adresse")),
         (INPUT_TYPE_CHECKBOX, _("Case à cocher")),

--- a/permits/search.py
+++ b/permits/search.py
@@ -218,7 +218,14 @@ def search_properties(search_str, permit_requests_qs, limit=None):
     qs = (
         add_score(
             models.WorksObjectPropertyValue.objects.filter(
-                property__input_type=models.WorksObjectProperty.INPUT_TYPE_TEXT,
+                property__input_type__in=[
+                    models.WorksObjectProperty.INPUT_TYPE_ADDRESS,
+                    models.WorksObjectProperty.INPUT_TYPE_LIST_MULTIPLE,
+                    models.WorksObjectProperty.INPUT_TYPE_LIST_SINGLE,
+                    models.WorksObjectProperty.INPUT_TYPE_NUMBER,
+                    models.WorksObjectProperty.INPUT_TYPE_TEXT,
+                    models.WorksObjectProperty.INPUT_TYPE_REGEX,
+                ],
                 works_object_type_choice__permit_request__in=permit_requests_qs,
             ).annotate(
                 txt_value=Cast(


### PR DESCRIPTION
Fix https://jira.liip.ch/browse/YC-607

Please review.

For now, the rendering of multiple list is like that:
![image](https://user-images.githubusercontent.com/4549666/152999524-e1804019-e12e-43b4-9a83-06828c2c42e4.png)


I don't know if we can improve this rendering without breaking the resumé layout.