### PR TITLE
Revert django-allauth update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ django==3.2.12
     #   djangorestframework
 django-admin-sortable2==1.0.4
     # via -r requirements.in
-django-allauth==0.48.0
+django-allauth==0.45.0
     # via -r requirements.in
 django-axes==5.31.0
     # via -r requirements.in

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -85,7 +85,7 @@ django==3.2.12
     #   djangorestframework
 django-admin-sortable2==1.0.4
     # via -r requirements.txt
-django-allauth==0.48.0
+django-allauth==0.45.0
     # via -r requirements.txt
 django-axes==5.31.0
     # via -r requirements.txt


### PR DESCRIPTION
Related to #415 

Social login was broken...

Perhaps something related to:
- https://django-allauth.readthedocs.io/en/latest/release-notes.html#backwards-incompatible-changes-2
- https://django-allauth.readthedocs.io/en/latest/release-notes.html#backwards-incompatible-changes-1