### PR TITLE
YC-599: Fix display of `*` for mandatory checkboxes

### DIFF
--- a/static/css/permits.css
+++ b/static/css/permits.css
@@ -177,6 +177,18 @@ input:focus {
   content: " *";
 }
 
+.required > label.custom-control-label:after {
+  content: "";
+}
+
+.required > label.custom-control-label > .asteriskField {
+  display: initial;
+}
+
+.required > label.custom-control-label > .asteriskField:before {
+  content: " ";
+}
+
 .app-list li {
   margin: 0 0 15px 0;
   list-style-type: none;


### PR DESCRIPTION
Fix https://jira.liip.ch/browse/YC-599

Please review.

Before:
![image](https://user-images.githubusercontent.com/4549666/171876243-5009d5e0-04bf-4ebe-9bdf-a2f87b0f15e5.png)

After:
![image](https://user-images.githubusercontent.com/4549666/171876271-0aaea29d-02cd-4254-95d3-3e44241b79f7.png)
