### PR TITLE
Tokens: replace `rest_framework.authtoken` by `django-rest-knox`

### DIFF
--- a/geomapshark/settings.py
+++ b/geomapshark/settings.py
@@ -133,7 +133,7 @@ INSTALLED_APPS = [
     "django_filters",
     "rest_framework",
     "rest_framework_gis",
-    "rest_framework.authtoken",
+    "knox",
     "bootstrap4",
     "bootstrap_datepicker_plus",
     "django_tables2",
@@ -536,7 +536,7 @@ REST_FRAMEWORK = {
 # Allow TokenAuthentication to the API.
 if DRF_ALLOW_TOKENAUTHENTICATION:
     REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"] += (
-        "rest_framework.authentication.TokenAuthentication",
+        "knox.auth.TokenAuthentication",
     )
 
 WFS3_TITLE = "OGC API Features - Geocity"

--- a/geomapshark/settings_test.py
+++ b/geomapshark/settings_test.py
@@ -10,9 +10,7 @@ PASSWORD_HASHERS = [
 ]
 # For tests, Token authentication is set to True
 DRF_ALLOW_TOKENAUTHENTICATION = True
-REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"] += (
-    "rest_framework.authentication.TokenAuthentication",
-)
+REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"] += ("knox.auth.TokenAuthentication",)
 SITE_ID = 1
 SITE_DOMAIN = "localhost"
 

--- a/geomapshark/urls.py
+++ b/geomapshark/urls.py
@@ -144,6 +144,7 @@ urlpatterns += [
     path("admin/", admin.site.urls),
     path("oauth/", include("oauth2_provider.urls", namespace="oauth2_provider")),
     path("captcha/", include("captcha.urls")),
+    path("api-tokens/", include("knox.urls")),
 ]
 
 if settings.PREFIX_URL:

--- a/permits/admin.py
+++ b/permits/admin.py
@@ -20,8 +20,6 @@ from django.urls import re_path, reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
-from rest_framework.authtoken.admin import TokenAdmin as BaseTokenAdmin
-from rest_framework.authtoken.models import TokenProxy
 
 from geomapshark import settings
 
@@ -52,10 +50,6 @@ OTHER_PERMISSIONS_CODENAMES = [
     "delete_group",
     "see_private_requests",
     # DRF Token authentication
-    "view_tokenproxy",
-    "add_tokenproxy",
-    "change_tokenproxy",
-    "delete_tokenproxy",
 ]
 
 if not settings.ALLOW_REMOTE_USER_AUTH:
@@ -1335,45 +1329,6 @@ class TemplateCustomizationAdmin(admin.ModelAdmin):
     has_background_image.short_description = "Image de fond"
 
 
-# AuthToken admin
-
-
-class TokenAdmin(BaseTokenAdmin):
-    list_display = [
-        "__str__",
-        "user",
-        "created",
-    ]
-    list_filter = [
-        "user",
-        "created",
-    ]
-    search_fields = [
-        "user",
-    ]
-
-    def get_queryset(self, request):
-        if request.user.is_superuser:
-            return TokenProxy.objects.all()
-        else:
-            return TokenProxy.objects.filter(user=request.user)
-
-    def has_add_permission(self, request):
-        if request.user.is_superuser:
-            return True
-        return False
-
-    def get_readonly_fields(self, request, obj=None):
-        if request.user.is_superuser:
-            return []
-        else:
-            return [
-                "user",
-                "key",
-                "created",
-            ]
-
-
 class ComplementaryDocumentTypeAdmin(IntegratorFilterMixin, admin.ModelAdmin):
     form = permit_forms.ComplementaryDocumentTypeAdminForm
 
@@ -1409,9 +1364,6 @@ class PermitRequestInquiryAdmin(admin.ModelAdmin):
     sortable_str.admin_order_field = "name"
     sortable_str.short_description = _("3.2 Enquêtes public")
 
-
-admin.site.unregister(TokenProxy)
-admin.site.register(TokenProxy, TokenAdmin)
 
 admin.site.register(models.PermitActorType, PermitActorTypeAdmin)
 admin.site.register(models.WorksType, WorksTypeAdmin)

--- a/permits/tests/test_permit_request_api.py
+++ b/permits/tests/test_permit_request_api.py
@@ -11,7 +11,7 @@ from django.contrib.gis.geos import (
     Point,
 )
 from django.test import TestCase
-from rest_framework.authtoken.models import Token
+from knox.models import AuthToken
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
@@ -404,9 +404,9 @@ class PermitRequestAPITestCase(TestCase):
 
     def test_api_is_accessible_with_token_authentication(self):
         # Create token
-        token = Token.objects.create(user=self.admin_user)
+        auth_token, token = AuthToken.objects.create(user=self.admin_user)
         # Set token in header
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
         response = self.client.get(reverse("permits-list"), {})
         response_json = response.json()
         permit_requests = models.PermitRequest.objects.all().only("id")

--- a/requirements.in
+++ b/requirements.in
@@ -40,3 +40,4 @@ django-cron
 django-axes
 pdf2image
 django-simple-captcha
+django-rest-knox

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ charset-normalizer==2.0.12
     # via requests
 cryptography==36.0.1
     # via
+    #   django-rest-knox
     #   jwcrypto
     #   pyjwt
 defusedxml==0.7.1
@@ -42,6 +43,7 @@ django==3.2.13
     #   django-phonenumber-field
     #   django-picklefield
     #   django-ranged-response
+    #   django-rest-knox
     #   django-simple-captcha
     #   django-tables2
     #   django-tables2-column-shifter
@@ -86,6 +88,8 @@ django-picklefield==3.0.1
     # via django-constance
 django-ranged-response==0.2.0
     # via django-simple-captcha
+django-rest-knox==4.2.0
+    # via -r requirements.in
 django-simple-captcha==0.5.17
     # via -r requirements.in
 django-simple-history==3.0.0
@@ -103,6 +107,7 @@ django-two-factor-auth[phonenumbers]==1.13.2
 djangorestframework==3.13.1
     # via
     #   -r requirements.in
+    #   django-rest-knox
     #   djangorestframework-gis
 djangorestframework-gis==0.18
     # via -r requirements.in

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -39,6 +39,7 @@ coverage==6.4.1
 cryptography==36.0.1
     # via
     #   -r requirements.txt
+    #   django-rest-knox
     #   jwcrypto
     #   pyjwt
 decorator==5.1.1
@@ -75,6 +76,7 @@ django==3.2.13
     #   django-phonenumber-field
     #   django-picklefield
     #   django-ranged-response
+    #   django-rest-knox
     #   django-simple-captcha
     #   django-tables2
     #   django-tables2-column-shifter
@@ -137,6 +139,8 @@ django-ranged-response==0.2.0
     # via
     #   -r requirements.txt
     #   django-simple-captcha
+django-rest-knox==4.2.0
+    # via -r requirements.txt
 django-simple-captcha==0.5.17
     # via -r requirements.txt
 django-simple-history==3.0.0
@@ -154,6 +158,7 @@ django-two-factor-auth[phonenumbers]==1.13.2
 djangorestframework==3.13.1
     # via
     #   -r requirements.txt
+    #   django-rest-knox
     #   djangorestframework-gis
 djangorestframework-gis==0.18
     # via -r requirements.txt


### PR DESCRIPTION
Since this is quite a sensitive topic, will split changes related to tokens in small PRs so it can be properly reviewed.

This replaces rest_framework.authtoken by django-rest-knox instead. Rationale for the change described here: https://james1345.github.io/django-rest-knox/

I **think** this could be merged independently from the reports branch.

@AlexandreJunod @monodo Please review carefully, there may be side effects, and don't know the test suite well enough yet to know whether we can rely on it for this kind of changes.

(btw, tokens are created via http://localhost:9095/api-tokens/login/)