### PR TITLE
YC-858: Use allauth specific version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ filetype
 # Open authentication provider
 django-oauth-toolkit
 # Open authentication consumer
-django-allauth
+django-allauth==0.45.0
 # django_wfs3 -> djangorestframework (optional for openapi schema generation, see https://www.django-rest-framework.org/api-guide/schemas/#install-dependencies)
 pyyaml
 uritemplate

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ django==3.2.15
     #   djangorestframework
 django-admin-sortable2==1.0.4
     # via -r requirements.in
-django-allauth==0.51.0
+django-allauth==0.45.0
     # via -r requirements.in
 django-axes==5.31.0
     # via -r requirements.in

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -90,7 +90,7 @@ django==3.2.15
     #   djangorestframework
 django-admin-sortable2==1.0.4
     # via -r requirements.txt
-django-allauth==0.51.0
+django-allauth==0.45.0
     # via -r requirements.txt
 django-axes==5.31.0
     # via -r requirements.txt


### PR DESCRIPTION
Fix https://jira.liip.ch/browse/YC-858

Stick allauth to specific version, same as done in #416, to make social login working...