### PR TITLE
YC-882 fix flaky report rendering tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,4 +53,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test-output-images
-        path: ./reports/tests/data
+        path: ./geocity/apps/reports/tests/data

--- a/geocity/apps/reports/tests/base.py
+++ b/geocity/apps/reports/tests/base.py
@@ -225,11 +225,12 @@ class ReportsTestsBase(LiveServerTestCase):
                 diff_img_file=diff_path,
             )
 
-            # We do not tolerate the slighest rendering difference. At some point we may need to implement
+            # For now we tolerate very small difference (0.01%) which seem to happen for unknown reason,
+            # maybe difference in antialiasing or whatnot. At some point we may need to implement
             # support for masks (areas that are not compared) to allow negligible rendering differences,
             # e.g. for QGIS updates.
-            if ratio > 0:
-                differences.append(f"{page_name}: {ratio*100:.2f}%")
+            if ratio > 0.0001:
+                differences.append(f"{page_name}: {ratio*100}%")
 
         if differences:
             differences_txt = "\n".join(differences)


### PR DESCRIPTION
Adds some very small tolerance to report rendering tests.

Also includes a follow up to the main refactoring which broke uploading the tests artifacts to the CI pipeline