### PR TITLE
YC-883: Add objects list in emails

### DIFF
--- a/geocity/apps/permits/cron.py
+++ b/geocity/apps/permits/cron.py
@@ -7,11 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from django_cron import CronJobBase, Schedule
 
 from .models import PermitRequest, PermitRequestInquiry
-from .services import (
-    get_works_object_names_list,
-    get_works_type_names_list,
-    send_email_notification,
-)
+from .services import send_email_notification
 
 logger = logging.getLogger(__name__)
 
@@ -49,13 +45,13 @@ class PermitRequestExpirationReminder(CronJobBase):
                     data = {
                         "subject": "{} ({})".format(
                             _("Votre autorisation arrive bientôt à échéance"),
-                            get_works_type_names_list(permit_request),
+                            permit_request.get_works_type_names_list(),
                         ),
                         "users_to_notify": [permit_request.author.user.email],
                         "template": "permit_request_prolongation_reminder.txt",
                         "permit_request": permit_request,
                         "absolute_uri_func": PermitRequest.get_absolute_url,
-                        "objects_list": get_works_object_names_list(permit_request),
+                        "objects_list": permit_request.get_works_object_names_list(),
                     }
                     send_email_notification(data)
 
@@ -105,7 +101,7 @@ class PermitRequestInquiryClosing(CronJobBase):
             data = {
                 "subject": "{} ({})".format(
                     _("Fin de l'enquête publique"),
-                    get_works_type_names_list(inquiry.permit_request),
+                    inquiry.permit_request.get_works_type_names_list(),
                 ),
                 "users_to_notify": [
                     inquiry.permit_request.author.user.email,
@@ -114,7 +110,7 @@ class PermitRequestInquiryClosing(CronJobBase):
                 "permit_request": inquiry.permit_request,
                 "absolute_uri_func": inquiry.permit_request.get_absolute_url,
                 "template": "permit_request_inquiry_closing.txt",
-                "objects_list": get_works_object_names_list(inquiry.permit_request),
+                "objects_list": inquiry.permit_request.get_works_object_names_list(),
             }
             send_email_notification(data)
 

--- a/geocity/apps/permits/forms.py
+++ b/geocity/apps/permits/forms.py
@@ -1169,8 +1169,10 @@ class PermitRequestAdditionalInformationForm(forms.ModelForm):
             template="permit_request_changed.txt",
             sender=sender,
             receivers=[permit_request.author.user.email],
-            subject=_("Votre demande %s a changé de statut")
-            % permit_request.works_objects_str(),
+            subject="{} ({})".format(
+                _("Votre demande a changé de statut"),
+                services.get_works_type_names_list(permit_request),
+            ),
             context={
                 "status": dict(permit_request.STATUS_CHOICES)[permit_request.status],
                 "reason": (
@@ -1186,6 +1188,7 @@ class PermitRequestAdditionalInformationForm(forms.ModelForm):
                 ),
                 "administrative_entity": permit_request.administrative_entity,
                 "name": permit_request.author.user.get_full_name(),
+                "objects_list": services.get_works_object_names_list(permit_request),
             },
         )
 

--- a/geocity/apps/permits/forms.py
+++ b/geocity/apps/permits/forms.py
@@ -1171,7 +1171,7 @@ class PermitRequestAdditionalInformationForm(forms.ModelForm):
             receivers=[permit_request.author.user.email],
             subject="{} ({})".format(
                 _("Votre demande a changé de statut"),
-                services.get_works_type_names_list(permit_request),
+                permit_request.get_works_type_names_list(),
             ),
             context={
                 "status": dict(permit_request.STATUS_CHOICES)[permit_request.status],
@@ -1188,7 +1188,7 @@ class PermitRequestAdditionalInformationForm(forms.ModelForm):
                 ),
                 "administrative_entity": permit_request.administrative_entity,
                 "name": permit_request.author.user.get_full_name(),
-                "objects_list": services.get_works_object_names_list(permit_request),
+                "objects_list": permit_request.get_works_object_names_list(),
             },
         )
 

--- a/geocity/apps/permits/models.py
+++ b/geocity/apps/permits/models.py
@@ -940,6 +940,16 @@ class PermitRequest(models.Model):
             )
         )
 
+    def get_works_object_names_list(self):
+
+        return ", ".join(
+            list(
+                self.works_object_types.all()
+                .values_list("works_object__name", flat=True)
+                .distinct()
+            )
+        )
+
     def archive(self, archivist):
         # make sure the request wasn't already archived
         if ArchivedPermitRequest.objects.filter(

--- a/geocity/apps/permits/services.py
+++ b/geocity/apps/permits/services.py
@@ -1116,13 +1116,13 @@ def submit_permit_request(permit_request, request):
         data = {
             "subject": "{} ({})".format(
                 _("La demande de compléments a été traitée"),
-                get_works_type_names_list(permit_request),
+                permit_request.get_works_type_names_list(),
             ),
             "users_to_notify": _get_secretary_email(permit_request),
             "template": "permit_request_complemented.txt",
             "permit_request": permit_request,
             "absolute_uri_func": request.build_absolute_uri,
-            "objects_list": get_works_object_names_list(permit_request),
+            "objects_list": permit_request.get_works_object_names_list(),
         }
         send_email_notification(data)
 
@@ -1156,23 +1156,23 @@ def submit_permit_request(permit_request, request):
 
         data = {
             "subject": "{} ({})".format(
-                _("Nouvelle demande"), get_works_type_names_list(permit_request)
+                _("Nouvelle demande"), permit_request.get_works_type_names_list()
             ),
             "users_to_notify": users_to_notify,
             "template": "permit_request_submitted.txt",
             "permit_request": permit_request,
             "absolute_uri_func": request.build_absolute_uri,
-            "objects_list": get_works_object_names_list(permit_request),
+            "objects_list": permit_request.get_works_object_names_list(),
         }
         send_email_notification(data)
 
         if permit_request.author.notify_per_email:
             data["subject"] = "{} ({})".format(
-                _("Votre demande"), get_works_type_names_list(permit_request)
+                _("Votre demande"), permit_request.get_works_type_names_list()
             )
             data["users_to_notify"] = [permit_request.author.user.email]
             data["template"] = "permit_request_acknowledgment.txt"
-            data["objects_list"] = get_works_object_names_list(permit_request)
+            data["objects_list"] = permit_request.get_works_object_names_list()
             send_email_notification(data)
 
     permit_request.status = models.PermitRequest.STATUS_SUBMITTED_FOR_VALIDATION
@@ -1208,13 +1208,13 @@ def request_permit_request_validation(permit_request, departments, absolute_uri_
     data = {
         "subject": "{} ({})".format(
             _("Nouvelle demande en attente de validation"),
-            get_works_type_names_list(permit_request),
+            permit_request.get_works_type_names_list(),
         ),
         "users_to_notify": users_to_notify,
         "template": "permit_request_validation_request.txt",
         "permit_request": permit_request,
         "absolute_uri_func": absolute_uri_func,
-        "objects_list": get_works_object_names_list(permit_request),
+        "objects_list": permit_request.get_works_object_names_list(),
     }
     send_email_notification(data)
 
@@ -1242,13 +1242,13 @@ def send_validation_reminder(permit_request, absolute_uri_func):
     data = {
         "subject": "{} ({})".format(
             _("Demande toujours en attente de validation"),
-            get_works_type_names_list(permit_request),
+            permit_request.get_works_type_names_list(),
         ),
         "users_to_notify": users_to_notify,
         "template": "permit_request_validation_reminder.txt",
         "permit_request": permit_request,
         "absolute_uri_func": absolute_uri_func,
-        "objects_list": get_works_object_names_list(permit_request),
+        "objects_list": permit_request.get_works_object_names_list(),
     }
     send_email_notification(data)
     return pending_validations
@@ -1907,14 +1907,6 @@ def download_file(path):
     # so we need to set the `Content-Type` to `application/octet-stream` so
     # firefox will download it. For the time being, this "dirty" hack works
     return FileResponse(storage.open(path), content_type="application/octet-stream")
-
-
-def get_works_type_names_list(permit_request):
-    return permit_request.get_works_type_names_list()
-
-
-def get_works_object_names_list(permit_request):
-    return permit_request.get_works_object_names_list()
 
 
 def download_archives(archive_ids, user):

--- a/geocity/apps/permits/services.py
+++ b/geocity/apps/permits/services.py
@@ -1122,6 +1122,7 @@ def submit_permit_request(permit_request, request):
             "template": "permit_request_complemented.txt",
             "permit_request": permit_request,
             "absolute_uri_func": request.build_absolute_uri,
+            "objects_list": get_works_object_names_list(permit_request),
         }
         send_email_notification(data)
 
@@ -1161,6 +1162,7 @@ def submit_permit_request(permit_request, request):
             "template": "permit_request_submitted.txt",
             "permit_request": permit_request,
             "absolute_uri_func": request.build_absolute_uri,
+            "objects_list": get_works_object_names_list(permit_request),
         }
         send_email_notification(data)
 
@@ -1170,6 +1172,7 @@ def submit_permit_request(permit_request, request):
             )
             data["users_to_notify"] = [permit_request.author.user.email]
             data["template"] = "permit_request_acknowledgment.txt"
+            data["objects_list"] = get_works_object_names_list(permit_request)
             send_email_notification(data)
 
     permit_request.status = models.PermitRequest.STATUS_SUBMITTED_FOR_VALIDATION
@@ -1211,6 +1214,7 @@ def request_permit_request_validation(permit_request, departments, absolute_uri_
         "template": "permit_request_validation_request.txt",
         "permit_request": permit_request,
         "absolute_uri_func": absolute_uri_func,
+        "objects_list": get_works_object_names_list(permit_request),
     }
     send_email_notification(data)
 
@@ -1244,6 +1248,7 @@ def send_validation_reminder(permit_request, absolute_uri_func):
         "template": "permit_request_validation_reminder.txt",
         "permit_request": permit_request,
         "absolute_uri_func": absolute_uri_func,
+        "objects_list": get_works_object_names_list(permit_request),
     }
     send_email_notification(data)
     return pending_validations
@@ -1292,6 +1297,7 @@ def send_email_notification(data):
             "administrative_entity": data["permit_request"].administrative_entity,
             "name": data["permit_request"].author.user.get_full_name(),
             "permit_request": data["permit_request"],
+            "objects_list": data["objects_list"],
         },
     )
 
@@ -1905,6 +1911,10 @@ def download_file(path):
 
 def get_works_type_names_list(permit_request):
     return permit_request.get_works_type_names_list()
+
+
+def get_works_object_names_list(permit_request):
+    return permit_request.get_works_object_names_list()
 
 
 def download_archives(archive_ids, user):

--- a/geocity/apps/permits/templates/permits/emails/permit_request_acknowledgment.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_acknowledgment.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
 
 {% trans "Nous vous confirmons bonne réception de votre demande et vous en remercions." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_changed.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_changed.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
 
 {% trans "Nous vous informons que votre demande a changé de statut." %}
 
@@ -15,5 +18,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_classified.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_classified.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
 
 {% trans "Nous vous informons que votre demande a été traitée et classée." %}
 
@@ -12,5 +15,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_classified_for_services.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_classified_for_services.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Bonjour{% endblocktrans %},
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% blocktrans %}Bonjour{% endblocktrans %},
 
 {% trans "Nous vous informons qu'une demande a été traitée et classée par le secrétariat." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_complemented.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_complemented.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% trans "Bonjour," %}
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% trans "Bonjour," %}
 
 {% trans "La demande de compléments a été traitée." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_inquiry_closing.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_inquiry_closing.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
 
 {% trans "Nous vous informons que l'enquête publique relative à la demande" %}: {{ permit_request_url }} est terminée.
 
@@ -8,5 +11,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_prolongation.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_prolongation.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
 
 {% trans "Nous vous informons que votre demande de prolongation a été traitée." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_prolongation_for_services.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_prolongation_for_services.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% trans "Bonjour," %}
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% trans "Bonjour," %}
 
 {% trans "Une demande de prolongation vient d'être soumise." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_prolongation_reminder.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_prolongation_reminder.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
 
 {% trans "Nous vous informons que votre autorisation arrive bientôt à échéance. Si vous n'effectuez pas de demande de prolongation, l'autorisation ne sera pas renouvelée." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_received.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_received.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% blocktrans %}Bonjour {{ name }}{% endblocktrans %},
 
 {% trans "Nous vous informons que votre annonce a été prise en compte et classée." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_received_for_services.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_received_for_services.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Bonjour{% endblocktrans %},
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% blocktrans %}Bonjour{% endblocktrans %},
 
 {% trans "Nous vous informons qu'une annonce a été prise en compte et classée par le secrétariat." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_submitted.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_submitted.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% trans "Bonjour," %}
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% trans "Bonjour," %}
 
 {% trans "Une nouvelle demande vient d'être soumise." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_submitted_with_mention.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_submitted_with_mention.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% trans "Bonjour," %}
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% trans "Bonjour," %}
 
 {% trans "Une nouvelle demande mentionnant votre service vient d'être soumise." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_validated.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_validated.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% trans "Bonjour," %}
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% trans "Bonjour," %}
 
 {% trans "Les services chargés de la validation d'une demande ont donné leur préavis." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_validation_reminder.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_validation_reminder.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% trans "Bonjour," %}
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% trans "Bonjour," %}
 
 {% trans "Une demande est toujours en attente de validation de votre part." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/templates/permits/emails/permit_request_validation_request.txt
+++ b/geocity/apps/permits/templates/permits/emails/permit_request_validation_request.txt
@@ -1,4 +1,7 @@
-{% load i18n %}{% autoescape off %}{% trans "Bonjour," %}
+{% load i18n %}{% autoescape off %}{{ objects_list }}
+
+
+{% trans "Bonjour," %}
 
 {% trans "Une nouvelle demande est en attente de validation de votre part." %}
 
@@ -10,5 +13,6 @@
 {% else %}
 {{ administrative_entity.name }}
 {% endif %}
+
 {% trans "Ceci est un e-mail automatique, veuillez ne pas y répondre." %}
 {% endautoescape %}

--- a/geocity/apps/permits/views.py
+++ b/geocity/apps/permits/views.py
@@ -568,13 +568,13 @@ class PermitRequestDetailView(View):
             data = {
                 "subject": "{} ({})".format(
                     _("Votre annonce a été prise en compte et classée"),
-                    services.get_works_type_names_list(permit_request),
+                    permit_request.get_works_type_names_list(),
                 ),
                 "users_to_notify": [permit_request.author.user.email],
                 "template": "permit_request_received.txt",
                 "permit_request": permit_request,
                 "absolute_uri_func": self.request.build_absolute_uri,
-                "objects_list": services.get_works_object_names_list(permit_request),
+                "objects_list": permit_request.get_works_object_names_list(),
             }
             services.send_email_notification(data)
 
@@ -587,15 +587,13 @@ class PermitRequestDetailView(View):
                         _(
                             "Une annonce a été prise en compte et classée par le secrétariat"
                         ),
-                        services.get_works_type_names_list(permit_request),
+                        permit_request.get_works_type_names_list(),
                     ),
                     "users_to_notify": set(mailing_list),
                     "template": "permit_request_received_for_services.txt",
                     "permit_request": permit_request,
                     "absolute_uri_func": self.request.build_absolute_uri,
-                    "objects_list": services.get_works_object_names_list(
-                        permit_request
-                    ),
+                    "objects_list": permit_request.get_works_object_names_list(),
                 }
                 services.send_email_notification(data)
 
@@ -671,7 +669,7 @@ class PermitRequestDetailView(View):
                             _(
                                 "Les services chargés de la validation d'une demande ont donné leur préavis"
                             ),
-                            services.get_works_type_names_list(self.permit_request),
+                            self.permit_request.get_works_type_names_list(),
                         ),
                         "users_to_notify": services._get_secretary_email(
                             self.permit_request
@@ -679,9 +677,7 @@ class PermitRequestDetailView(View):
                         "template": "permit_request_validated.txt",
                         "permit_request": self.permit_request,
                         "absolute_uri_func": self.request.build_absolute_uri,
-                        "objects_list": services.get_works_object_names_list(
-                            self.permit_request
-                        ),
+                        "objects_list": self.permit_request.get_works_object_names_list(),
                     }
                     services.send_email_notification(data)
             else:
@@ -733,13 +729,13 @@ class PermitRequestDetailView(View):
             data = {
                 "subject": "{} ({})".format(
                     subject,
-                    services.get_works_type_names_list(form.instance),
+                    form.instance.get_works_type_names_list(),
                 ),
                 "users_to_notify": [form.instance.author.user.email],
                 "template": "permit_request_prolongation.txt",
                 "permit_request": form.instance,
                 "absolute_uri_func": self.request.build_absolute_uri,
-                "objects_list": services.get_works_object_names_list(form.instance),
+                "objects_list": form.instance.get_works_object_names_list(),
             }
             services.send_email_notification(data)
 
@@ -1479,13 +1475,13 @@ def permit_request_prolongation(request, permit_request_id):
             data = {
                 "subject": "{} ({})".format(
                     _("Une demande de prolongation vient d'être soumise"),
-                    services.get_works_type_names_list(permit_request),
+                    permit_request.get_works_type_names_list(),
                 ),
                 "users_to_notify": services._get_secretary_email(permit_request),
                 "template": "permit_request_prolongation_for_services.txt",
                 "permit_request": form.instance,
                 "absolute_uri_func": request.build_absolute_uri,
-                "objects_list": services.get_works_object_names_list(permit_request),
+                "objects_list": permit_request.get_works_object_names_list(),
             }
             services.send_email_notification(data)
 
@@ -1907,13 +1903,13 @@ def permit_request_submit_confirmed(request, permit_request_id):
             data = {
                 "subject": "{} ({})".format(
                     _("Votre service à été mentionné dans une demande"),
-                    services.get_works_type_names_list(permit_request),
+                    permit_request.get_works_type_names_list(),
                 ),
                 "users_to_notify": set(mailing_list),
                 "template": "permit_request_submitted_with_mention.txt",
                 "permit_request": permit_request,
                 "absolute_uri_func": request.build_absolute_uri,
-                "objects_list": services.get_works_object_names_list(permit_request),
+                "objects_list": permit_request.get_works_object_names_list(),
             }
             services.send_email_notification(data)
 
@@ -2031,13 +2027,13 @@ def permit_request_classify(request, permit_request_id, approve):
             data = {
                 "subject": "{} ({})".format(
                     _("Votre demande a été traitée et classée"),
-                    services.get_works_type_names_list(permit_request),
+                    permit_request.get_works_type_names_list(),
                 ),
                 "users_to_notify": [permit_request.author.user.email],
                 "template": "permit_request_classified.txt",
                 "permit_request": permit_request,
                 "absolute_uri_func": request.build_absolute_uri,
-                "objects_list": services.get_works_object_names_list(permit_request),
+                "objects_list": permit_request.get_works_object_names_list(),
             }
             services.send_email_notification(data)
 
@@ -2048,15 +2044,13 @@ def permit_request_classify(request, permit_request_id, approve):
                 data = {
                     "subject": "{} ({})".format(
                         _("Une demande a été traitée et classée par le secrétariat"),
-                        services.get_works_type_names_list(permit_request),
+                        permit_request.get_works_type_names_list(),
                     ),
                     "users_to_notify": set(mailing_list),
                     "template": "permit_request_classified_for_services.txt",
                     "permit_request": permit_request,
                     "absolute_uri_func": request.build_absolute_uri,
-                    "objects_list": services.get_works_object_names_list(
-                        permit_request
-                    ),
+                    "objects_list": permit_request.get_works_object_names_list(),
                 }
                 services.send_email_notification(data)
 

--- a/geocity/apps/permits/views.py
+++ b/geocity/apps/permits/views.py
@@ -574,6 +574,7 @@ class PermitRequestDetailView(View):
                 "template": "permit_request_received.txt",
                 "permit_request": permit_request,
                 "absolute_uri_func": self.request.build_absolute_uri,
+                "objects_list": services.get_works_object_names_list(permit_request),
             }
             services.send_email_notification(data)
 
@@ -592,6 +593,9 @@ class PermitRequestDetailView(View):
                     "template": "permit_request_received_for_services.txt",
                     "permit_request": permit_request,
                     "absolute_uri_func": self.request.build_absolute_uri,
+                    "objects_list": services.get_works_object_names_list(
+                        permit_request
+                    ),
                 }
                 services.send_email_notification(data)
 
@@ -675,6 +679,9 @@ class PermitRequestDetailView(View):
                         "template": "permit_request_validated.txt",
                         "permit_request": self.permit_request,
                         "absolute_uri_func": self.request.build_absolute_uri,
+                        "objects_list": services.get_works_object_names_list(
+                            self.permit_request
+                        ),
                     }
                     services.send_email_notification(data)
             else:
@@ -718,18 +725,21 @@ class PermitRequestDetailView(View):
             messages.success(self.request, success_message)
 
             subject = (
-                _("Votre demande #%s a bien été prolongée.") % self.permit_request.pk
+                _("La prolongation de votre demande a été acceptée")
                 if form.instance.prolongation_status
                 == self.permit_request.PROLONGATION_STATUS_APPROVED
-                else _("La prolongation de votre demande #%s a été refusée.")
-                % self.permit_request.pk
+                else _("La prolongation de votre demande a été refusée")
             )
             data = {
-                "subject": subject,
+                "subject": "{} ({})".format(
+                    subject,
+                    services.get_works_type_names_list(form.instance),
+                ),
                 "users_to_notify": [form.instance.author.user.email],
                 "template": "permit_request_prolongation.txt",
                 "permit_request": form.instance,
                 "absolute_uri_func": self.request.build_absolute_uri,
+                "objects_list": services.get_works_object_names_list(form.instance),
             }
             services.send_email_notification(data)
 
@@ -1466,18 +1476,16 @@ def permit_request_prolongation(request, permit_request_id):
             # Send the email to the services
             messages.success(request, _("Votre demande de prolongation a été envoyée"))
 
-            subject = (
-                _(
-                    "Une demande de prolongation vient d'être soumise pour le permis #%s."
-                )
-                % permit_request_id
-            )
             data = {
-                "subject": subject,
+                "subject": "{} ({})".format(
+                    _("Une demande de prolongation vient d'être soumise"),
+                    services.get_works_type_names_list(permit_request),
+                ),
                 "users_to_notify": services._get_secretary_email(permit_request),
                 "template": "permit_request_prolongation_for_services.txt",
                 "permit_request": form.instance,
                 "absolute_uri_func": request.build_absolute_uri,
+                "objects_list": services.get_works_object_names_list(permit_request),
             }
             services.send_email_notification(data)
 
@@ -1897,11 +1905,15 @@ def permit_request_submit_confirmed(request, permit_request_id):
             ]
         if mailing_list:
             data = {
-                "subject": _("Votre service à été mentionné dans une demande"),
+                "subject": "{} ({})".format(
+                    _("Votre service à été mentionné dans une demande"),
+                    services.get_works_type_names_list(permit_request),
+                ),
                 "users_to_notify": set(mailing_list),
                 "template": "permit_request_submitted_with_mention.txt",
                 "permit_request": permit_request,
                 "absolute_uri_func": request.build_absolute_uri,
+                "objects_list": services.get_works_object_names_list(permit_request),
             }
             services.send_email_notification(data)
 
@@ -2025,6 +2037,7 @@ def permit_request_classify(request, permit_request_id, approve):
                 "template": "permit_request_classified.txt",
                 "permit_request": permit_request,
                 "absolute_uri_func": request.build_absolute_uri,
+                "objects_list": services.get_works_object_names_list(permit_request),
             }
             services.send_email_notification(data)
 
@@ -2041,6 +2054,9 @@ def permit_request_classify(request, permit_request_id, approve):
                     "template": "permit_request_classified_for_services.txt",
                     "permit_request": permit_request,
                     "absolute_uri_func": request.build_absolute_uri,
+                    "objects_list": services.get_works_object_names_list(
+                        permit_request
+                    ),
                 }
                 services.send_email_notification(data)
 


### PR DESCRIPTION
Fix https://jira.liip.ch/browse/YC-883

I also added the types list in mail subject https://github.com/yverdon/geocity/pull/408 where it was missing.