### PR TITLE
YC-610: Render line breaks for multiline text fields

### DIFF
--- a/geocity/apps/permits/templates/permits/_permit_request_summary.html
+++ b/geocity/apps/permits/templates/permits/_permit_request_summary.html
@@ -13,7 +13,7 @@
             {% for field in properties %}
               {% if field.label %}
                 <dt> {{ field.label }} </dt>
-                <dd> {{ field.value|human_field_value }} </dd>
+                <dd> {{ field.value|human_field_value|linebreaksbr }} </dd>
               {% else %}
                 <dt style="white-space: nowrap;">{{ field.repr|safe }}</dt>
                 <dd></dd>
@@ -41,7 +41,7 @@
               {% if object_property.property.is_visible_by_author or object_property.property.is_visible_by_validators and is_validator %}
                 <dl class="properties-list">
                   <dt class="amend-property">{{ object_property.property }}</dt>
-                  <dd>{{ object_property.value }}</dd>
+                  <dd>{{ object_property.value|linebreaksbr }}</dd>
                 </dl>
               {% endif %}
             {% endfor %}

--- a/geocity/apps/permits/templates/permits/permit_request_detail.html
+++ b/geocity/apps/permits/templates/permits/permit_request_detail.html
@@ -179,13 +179,13 @@
                   {% endif %}
                 </dd>
                 {% if validation.comment_before %}
-                  <dt>{% trans "Commentaire (avant)" %}:</dt> <dd> {{ validation.comment_before }} </dd>
+                  <dt>{% trans "Commentaire (avant)" %}:</dt> <dd> {{ validation.comment_before|linebreaksbr }} </dd>
                 {% endif %}
                 {% if validation.comment_during %}
-                  <dt>{% trans "Commentaire (pendant)" %}:</dt> <dd> {{ validation.comment_during }} </dd>
+                  <dt>{% trans "Commentaire (pendant)" %}:</dt> <dd> {{ validation.comment_during|linebreaksbr }} </dd>
                 {% endif %}
                 {% if validation.comment_after %}
-                  <dt>{% trans "Commentaire (après)" %}:</dt> <dd> {{ validation.comment_after }} </dd>
+                  <dt>{% trans "Commentaire (après)" %}:</dt> <dd> {{ validation.comment_after|linebreaksbr }} </dd>
                 {% endif %}
               </dl>
             </div>
@@ -203,7 +203,7 @@
           <dl>
           <dt>{{ permit_request.get_prolongation_status_display }}</dt>
           {% if permit_request.prolongation_comment %}
-            <h6>{% trans "Commentaire" %}:</h6> {{ permit_request.prolongation_comment }}
+            <h6>{% trans "Commentaire" %}:</h6> {{ permit_request.prolongation_comment|linebreaksbr }}
           {% endif %}
           </dl>
           <br>
@@ -225,7 +225,7 @@
         <h2>{% trans "Informations complémentaires" %}</h2>
         <dl>
             <dt>{% trans "Information sur la décision" %}</dt>
-            <dd>{{ permit_request.additional_decision_information }}</dd>
+            <dd>{{ permit_request.additional_decision_information|linebreaksbr }}</dd>
         </dl>
     </div></div>
     {% endif %}

--- a/geocity/apps/permits/templates/permits/permit_request_detail.html
+++ b/geocity/apps/permits/templates/permits/permit_request_detail.html
@@ -199,14 +199,19 @@
 
       <div class="row sub-row">
         <div class="col">
-          <h2>{% trans "Statut de Prolongation" %}</h2>
-          <dl>
-          <dt>{{ permit_request.get_prolongation_status_display }}</dt>
-          {% if permit_request.prolongation_comment %}
-            <h6>{% trans "Commentaire" %}:</h6> {{ permit_request.prolongation_comment|linebreaksbr }}
-          {% endif %}
-          </dl>
-          <br>
+          <h2>{% trans "Prolongation" %}</h2>
+          <div class="container">
+            <dl>
+              {% if permit_request.get_prolongation_status_display %}
+                <dt>{% trans "État" %}</dt>
+                <dd> {{ permit_request.get_prolongation_status_display }} </dd>
+              {% endif %}
+              {% if permit_request.prolongation_comment %}
+                <dt>{% trans "Commentaire" %}</dt>
+                <dd> {{ permit_request.prolongation_comment|linebreaksbr }} </dd>
+              {% endif %}
+            </dl>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Fix https://jira.liip.ch/browse/YC-610

After:
![image](https://user-images.githubusercontent.com/4549666/194329701-3ecdd4cc-f70c-4a4c-a5ec-0df14105f27c.png)

Before:
![image](https://user-images.githubusercontent.com/4549666/194329819-b64844f6-10c5-409b-a509-eeae79fc3938.png)
