### PR TITLE
Feature/show integrator users

### DIFF
--- a/geocity/apps/accounts/users.py
+++ b/geocity/apps/accounts/users.py
@@ -80,7 +80,8 @@ def get_users_list_for_integrator_admin(user):
             Q(is_superuser=False),
             Q(email_domain__in=email_domains) | Q(email__in=emails),
             Q(groups__permit_department__integrator=user_integrator_group.pk)
-            | Q(groups__isnull=True),
+            | Q(groups__isnull=True)
+            | Q(groups__permit_department__is_integrator_admin=True),
         )
         .exclude()
         .distinct()


### PR DESCRIPTION
The problem where the integrator role was removed on a save of the user is fixed, so there's no reason to keep the integrator hidden