### PR TITLE
Improve admin interface 

### DIFF
--- a/geocity/apps/forms/admin.py
+++ b/geocity/apps/forms/admin.py
@@ -496,7 +496,7 @@ class FormCategoryAdmin(IntegratorFilterMixin, admin.ModelAdmin):
         "get__tags",
     ]
     search_fields = [
-        "id",
+        "name",
     ]
 
     def sortable_str(self, obj):

--- a/geocity/apps/reports/admin.py
+++ b/geocity/apps/reports/admin.py
@@ -139,8 +139,8 @@ class ReportAdmin(
     ]
     search_fields = [
         "name",
-        "layout",
-        "integrator",
+        "layout__name",
+        "integrator__name",
     ]
 
     class Media:

--- a/geocity/apps/reports/templates/reports/sections/sectiondetail.html
+++ b/geocity/apps/reports/templates/reports/sections/sectiondetail.html
@@ -7,34 +7,31 @@
 {% block content %}
     {% if request_data.properties.submission_fields %}
         <div class="flex_container">
-            <div class="flex_item-100">
-                {% if section.style == 0 %}
-                    {% for form, fields in request_data.properties.submission_fields.items %}
-                        {% if section.show_form_name %}
-                            <h3>{{form}}</h3>
+            {% if section.style == 0 %}
+                {% for form, fields in request_data.properties.submission_fields.items %}
+                    {% if section.show_form_name %}
+                        <div class="flex_item-100"><h3>{{form}}</h3></div>
+                    {% endif %}
+                    {% for key, field in fields.items %}
+                        {% if not key in section.undesired_properties %}
+                            <div style="padding-top:{{section.line_height}}px;"><span class="bold">{{key}} : </span>{{field}}<br></div>
                         {% endif %}
-                        {% for key, field in fields.items %}
-                            {% if not key in section.undesired_properties %}
-                                <div style="padding-top:{{section.line_height}}px;"><span class="bold">{{key}} : </span>{{field}}<br></div>
-                            {% endif %}
-                        {% endfor %}
                     {% endfor %}
-            </div>
-                {% elif  section.style == 1 %}
-            </div>
-                    {% for form, fields in request_data.properties.submission_fields.items %}
-                        {% if section.show_form_name %}
-                            <h3>{{form}}</h3>
+                {% endfor %}
+            {% elif  section.style == 1 %}
+                {% for form, fields in request_data.properties.submission_fields.items %}
+                    {% if section.show_form_name %}
+                        <div class="flex_item-100"><h3>{{form}}</h3></div>
+                    {% endif %}
+                    {% for key, field in fields.items %}
+                        {% if not key in section.undesired_properties %}
+                            <div class="flex_item-40"><span class="bold">{{key}}</span></div>
+                            <div class="flex_item-60">{{field}}</div>
+                            <div style="padding-top:{{section.line_height}}px;"></div>
                         {% endif %}
-                        {% for key, field in fields.items %}
-                            {% if not key in section.undesired_properties %}
-                                <div class="flex_item-40"><span class="bold">{{key}}</span></div>
-                                <div class="flex_item-60">{{field}}</div>
-                                <div style="padding-top:{{section.line_height}}px;"></div>
-                            {% endif %}
-                        {% endfor %}
                     {% endfor %}
-                {% endif %}
+                {% endfor %}
+            {% endif %}
         </div>
     {% else %}
         <p>Aucune propriété pour cette demande</p>

--- a/geocity/apps/reports/templates/reports/sections/sectiondetail.html
+++ b/geocity/apps/reports/templates/reports/sections/sectiondetail.html
@@ -14,7 +14,7 @@
                     {% endif %}
                     {% for key, field in fields.items %}
                         {% if not key in section.undesired_properties %}
-                            <div style="padding-top:{{section.line_height}}px;"><span class="bold">{{key}} : </span>{{field}}<br></div>
+                            <div class="flex_item-100" style="padding-top:{{section.line_height}}px;"><span class="bold">{{key}} : </span>{{field}}<br></div>
                         {% endif %}
                     {% endfor %}
                 {% endfor %}


### PR DESCRIPTION
Make admin more easy to configure by adding more visibility of elements using : 
- get_list_display
- get_search_fields
- get_list_filter
- Custom data (like [this](https://github.com/yverdon/geocity/pull/750/files#diff-ab1253e47db5cfdade10f9bceb6b5a218f3b7d451c18810bf091e228c8fb467aL151))

Superuser and integrator should have a different view. Show usefull data to make it easier to retrieve elements