### PR TITLE
Rename forgotten permit_request variables

### DIFF
--- a/geocity/apps/submissions/templates/submissions/emails/submission_classified.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_classified.txt
@@ -3,8 +3,8 @@
 {% translate "Nous vous informons que votre demande a été traitée et classée." %}
 
 {% translate "Vous pouvez la consulter sur le lien suivant" %}: {{ submission_url }}
-{% if permit_request.additional_decision_information %}
-{{ permit_request.additional_decision_information }}
+{% if submission.additional_decision_information %}
+{{ submission.additional_decision_information }}
 {% endif %}
 {% translate "Avec nos meilleures salutations," %}
 {% if administrative_entity.custom_signature %}

--- a/geocity/apps/submissions/templates/submissions/submission_geo_time.html
+++ b/geocity/apps/submissions/templates/submissions/submission_geo_time.html
@@ -13,7 +13,7 @@
   <hr>
   {% directives_and_legal_cta submission %}
   <form method="post">
-    <div data-geo-time-role="forms" data-nb-forms="{{ formset.forms|length }}" data-permit-duration-max="{{ permit_request.max_validity }}">
+    <div data-geo-time-role="forms" data-nb-forms="{{ formset.forms|length }}" data-permit-duration-max="{{ submission.max_validity }}">
       {% for form in formset.forms %}
         {{ form.media }}
         {% include "submissions/_geo_time_form.html" with form=form form_id=forloop.counter0 form_number=forloop.counter open=forloop.last %}


### PR DESCRIPTION
Not sure if it's also recommended to rename [here](https://github.com/yverdon/geocity/blob/main/geocity/apps/submissions/shortcuts.py#L14) (since `submission` is already set)?