### PR TITLE
YG-559 pdf uploads

### DIFF
--- a/geocity/apps/submissions/services.py
+++ b/geocity/apps/submissions/services.py
@@ -296,7 +296,9 @@ def download_file(path):
     # for some strange reason, firefox refuses to download the file.
     # so we need to set the `Content-Type` to `application/octet-stream` so
     # firefox will download it. For the time being, this "dirty" hack works
-    return FileResponse(storage.open(path), content_type="application/octet-stream")
+    return FileResponse(
+        storage.open(path), content_type="application/octet-stream", as_attachment=True
+    )
 
 
 def download_archives(archive_ids, user):


### PR DESCRIPTION
This PR forces downloading files so that they are not opened in the geocity domain.
I tested it on Firefox and it worked.

Should I remove the pdf-imagifying code? Or maybe put it behind a setting?