### PR TITLE
Display the text of select at the same place as before

### DIFF
--- a/geocity/apps/core/static/css/main.css
+++ b/geocity/apps/core/static/css/main.css
@@ -921,4 +921,9 @@ img.captcha {
   height: calc(1.5em + .75rem + 2px) !important;
 }
 
+.select2-container .select2-selection--single .select2-selection__rendered {
+  padding-left: 12px !important;
+  padding-top: 4px !important;
+}
+
 /* END Django-Select2 tuning */


### PR DESCRIPTION
After fix:
![image](https://github.com/yverdon/geocity/assets/4549666/6a40d3b0-aaae-4621-9f52-0639d9ddb3e4)

Before fix:
![image](https://github.com/yverdon/geocity/assets/4549666/69b6ac2b-b379-433b-8d39-e89e6ae69a5b)
