### PR TITLE
Use a better color for status processing

### DIFF
--- a/geocity/apps/core/static/css/main.css
+++ b/geocity/apps/core/static/css/main.css
@@ -468,7 +468,7 @@ th.actions {
 }
 .status3 {
   /* STATUS_PROCESSING */
-  color: #2FA4A2;
+  color: #d075e7;
 }
 .status4 {
   /* STATUS_AWAITING_SUPPLEMENT */

--- a/geocity/apps/core/static/css/main.css
+++ b/geocity/apps/core/static/css/main.css
@@ -456,11 +456,11 @@ th.actions {
 
 .status0 {
   /* STATUS_DRAFT */
-  color: #DADBDF;
+  color: #dadbdf;
 }
 .status1 {
   /* STATUS_SUBMITTED_FOR_VALIDATION */
-  color: #F88C52;
+  color: #f88c52;
 }
 .status2 {
   /* STATUS_APPROVED */
@@ -472,19 +472,19 @@ th.actions {
 }
 .status4 {
   /* STATUS_AWAITING_SUPPLEMENT */
-  color: #BD5947;
+  color: #bd5947;
 }
 .status5 {
   /* STATUS_AWAITING_VALIDATION */
-  color: #4285B0;
+  color: #4285b0;
 }
 .status6 {
   /* STATUS_REJECTED */
-  color: #DB5033;
+  color: #db5033;
 }
 .status7 {
   /* STATUS_RECEIVED */
-  color: #A0B46F;
+  color: #a0b46f;
 }
 
 /* TRANSACTION STATUSES */


### PR DESCRIPTION
Currently the color is too close to the status accepted

After:
![image](https://github.com/yverdon/geocity/assets/4549666/617dd130-a6f4-4fbb-890e-bc6f467d004f)

Before:
![image](https://github.com/yverdon/geocity/assets/4549666/08243414-a968-4029-8c9d-6c9233f93571)
