### PR TITLE
add entities the integrator is in from other groups

### DIFF
--- a/geocity/apps/forms/models.py
+++ b/geocity/apps/forms/models.py
@@ -135,7 +135,9 @@ class FormQuerySet(models.QuerySet):
             if integrator_admin:
                 """An integrator can fill all forms he owns + public ones"""
                 queryset = queryset.filter(
-                    Q(integrator=integrator_admin) | Q(forms__is_public=True)
+                    Q(integrator=integrator_admin)
+                    | Q(forms__is_public=True)
+                    | Q(pk__in=user_administrative_entities)
                 )
             elif user_administrative_entities and user_can_view_private_form:
                 """User is trusted and associated to administrative entities,


### PR DESCRIPTION
When an integrator is also in a pilot group, he should see both administrative entites he created but also thoses associated to other groups he's in.