### PR TITLE
Remove author name falsely used as recipient name in backoffice emails

### DIFF
--- a/geocity/apps/submissions/templates/submissions/emails/submission_classified_for_services.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_classified_for_services.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktranslate %}Bonjour {{ name }}{% endblocktranslate %},
+{% load i18n %}{% autoescape off %}{% translate "Bonjour," %}
 
 {% translate "Nous vous informons qu'une demande a été traitée et classée par le secrétariat." %}
 

--- a/geocity/apps/submissions/templates/submissions/emails/submission_complemented.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_complemented.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktranslate %}Bonjour {{ name }}{% endblocktranslate %},
+{% load i18n %}{% autoescape off %}{% translate "Bonjour," %}
 
 {% translate "La demande de compléments a été traitée." %}
 

--- a/geocity/apps/submissions/templates/submissions/emails/submission_prolongation_for_services.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_prolongation_for_services.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktranslate %}Bonjour {{ name }}{% endblocktranslate %},
+{% load i18n %}{% autoescape off %}{% translate "Bonjour," %}
 
 {% translate "Une demande de prolongation vient d'être soumise." %}
 

--- a/geocity/apps/submissions/templates/submissions/emails/submission_received_for_services.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_received_for_services.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktranslate %}Bonjour {{ name }}{% endblocktranslate %},
+{% load i18n %}{% autoescape off %}{% translate "Bonjour," %}
 
 {% translate "Nous vous informons qu'une demande/annonce a été prise en compte et classée par le secrétariat." %}
 

--- a/geocity/apps/submissions/templates/submissions/emails/submission_submitted.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_submitted.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktranslate %}Bonjour {{ name }}{% endblocktranslate %},
+{% load i18n %}{% autoescape off %}{% translate "Bonjour," %}
 
 {% translate "Une nouvelle demande/annonce vient d'être soumise." %}
 

--- a/geocity/apps/submissions/templates/submissions/emails/submission_submitted_with_mention.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_submitted_with_mention.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktranslate %}Bonjour {{ name }}{% endblocktranslate %},
+{% load i18n %}{% autoescape off %}{% translate "Bonjour," %}
 
 {% translate "Une nouvelle demande/annonce mentionnant votre service vient d'être soumise." %}
 

--- a/geocity/apps/submissions/templates/submissions/emails/submission_validated.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_validated.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktranslate %}Bonjour {{ name }}{% endblocktranslate %},
+{% load i18n %}{% autoescape off %}{% translate "Bonjour," %}
 
 {% translate "Les services chargés de la validation d'une demande ont donné leur préavis." %}
 

--- a/geocity/apps/submissions/templates/submissions/emails/submission_validation_reminder.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_validation_reminder.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktranslate %}Bonjour {{ name }}{% endblocktranslate %},
+{% load i18n %}{% autoescape off %}{% translate "Bonjour," %}
 
 {% translate "Une demande est toujours en attente de validation de votre part." %}
 

--- a/geocity/apps/submissions/templates/submissions/emails/submission_validation_request.txt
+++ b/geocity/apps/submissions/templates/submissions/emails/submission_validation_request.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktranslate %}Bonjour {{ name }}{% endblocktranslate %},
+{% load i18n %}{% autoescape off %}{% translate "Bonjour," %}
 
 {% translate "Une nouvelle demande est en attente de validation de votre part." %}
 


### PR DESCRIPTION
Wrong implementation in https://github.com/yverdon/geocity/pull/936