### PR TITLE
allow configuration in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,3 +104,5 @@ USE_THUMBOR=false
 # For dockerized thumbor service not exposed over the Internet, attache Geocity to its network with this override on top of this file:
 # COMPOSE_FILE=docker-compose.yml:docker-compose.thumbor.yml
 THUMBOR_SERVICE_URL="http://nginx-proxy"
+# https://docs.djangoproject.com/en/5.0/ref/settings/#csrf-trusted-origins
+CSRF_TRUSTED_ORIGINS=https://yoursite.geocity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       SITE_DOMAIN:
       USE_THUMBOR:
       THUMBOR_SERVICE_URL:
+      CSRF_TRUSTED_ORIGINS:
     ports:
       - "${DJANGO_DOCKER_PORT}:9000"
     networks:

--- a/geocity/settings.py
+++ b/geocity/settings.py
@@ -42,6 +42,8 @@ SESSION_COOKIE_SAMESITE = os.getenv("SESSION_COOKIE_SAMESITE", "Strict")
 
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
+CSRF_TRUSTED_ORIGINS = os.getenv("CSRF_TRUSTED_ORIGINS").split(",")
+
 
 # SESSION TIMEOUT
 # default session time is one hour


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.0/ref/settings/#csrf-trusted-origins