### PR TITLE
YC-1146 (revival): Re add possibility to skip validation by validators step

### DIFF
--- a/geocity/apps/submissions/templates/submissions/_submission_actions.html
+++ b/geocity/apps/submissions/templates/submissions/_submission_actions.html
@@ -18,7 +18,7 @@
                  aria-selected="{% if active_form == "amend" %}true{% else %}false{% endif %}">{% translate "Traitement" %}</a>
             </li>
           {% endif %}
-          {% if not submission.is_classified and forms.request_validation %}
+          {% if not submission.is_classified and forms.request_validation and not submission.validation_by_validators_is_disabled %}
             <li class="nav-item">
               <a class="btn btn-primary btn-action nav-link{% if active_form == "request_validation" %} active{% endif %}"
                  id="request-validation-tab"
@@ -199,7 +199,7 @@
               {% endif %}
             </div>
           {% endif %}
-          {% if not submission.is_classified and forms.request_validation %}
+          {% if not submission.is_classified and forms.request_validation and not submission.validation_by_validators_is_disabled %}
             <div class="tab-pane{% if active_form == "request_validation" %} show active{% endif %}"
                  id="request-validation"
                  role="tabpanel"


### PR DESCRIPTION
The condition added in https://github.com/yverdon/geocity/pull/910/files#diff-a9ad40719e1ddddf96d55340a7a38e6694d31375c596ed440823f71dbdc26bc0 was removed (unintentionally?) in https://github.com/yverdon/geocity/commit/6f2103402be4a307cf7d2ede970cb823a0a4e71a#diff-a9ad40719e1ddddf96d55340a7a38e6694d31375c596ed440823f71dbdc26bc0R21 in https://github.com/yverdon/geocity/pull/925, so the possibility to skip validation by validators step wasn't working anymore...

This PR fixes that.